### PR TITLE
Add Component, Event and Session data types

### DIFF
--- a/testctrl/svc/types/component.go
+++ b/testctrl/svc/types/component.go
@@ -1,0 +1,114 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	pb "github.com/grpc/grpc/testctrl/genproto/testctrl/svc"
+)
+
+// Component represents a dependency for a session. Benchmarks tend to have three components: a
+// driver, server and client. Each component can have many identical replicas.
+type Component struct {
+	name      string
+	container string
+	kind      ComponentKind
+	replicas  int32
+	env       map[string]string
+}
+
+// NewComponent creates a Component instance, given a container, kind and replicas.
+//
+// The container string should contain the path to a docker image in a registry, versioned by an
+// explicit tag or hash. Replicas should be 1 for drivers and servers. For clients, they may be
+// any positive integer.
+//
+// For example:
+//
+//     // Container uses "nginx" image with explicit tag "latest" from docker hub
+//     a := NewComponent("nginx:latest", ServerComponent, 1)
+//
+//     // Container uses "java_worker" image with explicit tag "v3.2.2" from GCR with 2 replicas
+//     b := NewComponent("gcr.io/grpc-testing/java_worker:v3.2.2", ClientComponent, 2)
+//
+//     // Container uses "driver" image with hash from GCR
+//     c := NewComponent("gcr.io/grpc-testing/driver@sha256:e4ff8efd7eb62d3a3bb0990f6ff1e9df20da24ebf908d08f49cb83422a232862", DriverComponent, 1)
+func NewComponent(container string, kind ComponentKind, replicas int32) *Component {
+	return &Component{
+		name:      fmt.Sprintf("components/%s", uuid.New().String()),
+		container: container,
+		kind:      kind,
+		replicas:  replicas,
+	}
+}
+
+// Name returns a string that uniquely identifies a component. This name is shared by all replicas,
+// but it is not shared by any other component in the same session or any identical component in
+// another session.
+func (c *Component) Name() string {
+	return c.name
+}
+
+// Container returns the name of a docker image and tag which contains the required component.
+func (c *Component) Container() string {
+	return c.container
+}
+
+// Kind returns the type of component.
+func (c *Component) Kind() ComponentKind {
+	return c.kind
+}
+
+// Replicas returns the number of replicas of this component.
+func (c *Component) Replicas() int32 {
+	return c.replicas
+}
+
+// SetEnv stores an environment variable that must be set on the component. Setting one after a
+// component is running will have no effect.
+func (c *Component) SetEnv(key, value string) {
+	c.env[key] = value
+}
+
+// ComponentKind specifies the type of component the test requires.
+type ComponentKind int32
+
+const (
+	// DriverComponent is a test component that orchestrates workers, such as clients and servers.
+	DriverComponent ComponentKind = iota
+
+	// ClientComponent feeds traffic to a server component.
+	ClientComponent
+
+	// ServerComponent accepts traffic from a client component.
+	ServerComponent
+)
+
+// ComponentKindFromProto takes the generated protobuf enum type and safely converts it into a
+// ComponentKind. It ensures the string representations are equivalent, even if values change.
+func ComponentKindFromProto(p pb.Component_Kind) ComponentKind {
+	return componentKindStringToConstMap[p.String()]
+}
+
+// String returns the string representation of the ComponentKind.
+func (k ComponentKind) String() string {
+	return componentKindConstToStringMap[k]
+}
+
+// Proto converts the ComponentKind enum into the generated protobuf enum. It ensures the string
+// representations are equivalent, even if values change.
+func (k ComponentKind) Proto() pb.Component_Kind {
+	return pb.Component_Kind(pb.Component_Kind_value[k.String()])
+}
+
+var componentKindStringToConstMap = map[string]ComponentKind{
+	"DRIVER": DriverComponent,
+	"CLIENT": ClientComponent,
+	"SERVER": ServerComponent,
+}
+
+var componentKindConstToStringMap = map[ComponentKind]string{
+	DriverComponent: "DRIVER",
+	ClientComponent: "CLIENT",
+	ServerComponent: "SERVER",
+}

--- a/testctrl/svc/types/component.go
+++ b/testctrl/svc/types/component.go
@@ -35,7 +35,7 @@ type Component struct {
 //     c := NewComponent("gcr.io/grpc-testing/driver@sha256:e4ff8efd7eb62d3a3bb0990f6ff1e9df20da24ebf908d08f49cb83422a232862", DriverComponent, 1)
 func NewComponent(container string, kind ComponentKind, replicas int32) *Component {
 	return &Component{
-		name:      fmt.Sprintf("components/%s", uuid.New().String()),
+		name:      uuid.New().String(),
 		container: container,
 		kind:      kind,
 		replicas:  replicas,
@@ -47,6 +47,12 @@ func NewComponent(container string, kind ComponentKind, replicas int32) *Compone
 // another session.
 func (c *Component) Name() string {
 	return c.name
+}
+
+// ResourceName returns the name the component prefixed with `components/`. This value should be
+// displayed to a consumer of the API.
+func (c *Component) ResourceName() string {
+	return fmt.Sprintf("components/%s", c.Name())
 }
 
 // Container returns the name of a docker image and tag which contains the required component.

--- a/testctrl/svc/types/component.go
+++ b/testctrl/svc/types/component.go
@@ -80,8 +80,10 @@ func (c *Component) SetEnv(key, value string) {
 type ComponentKind int32
 
 const (
+	_ ComponentKind = iota
+
 	// DriverComponent is a test component that orchestrates workers, such as clients and servers.
-	DriverComponent ComponentKind = iota
+	DriverComponent
 
 	// ClientComponent feeds traffic to a server component.
 	ClientComponent

--- a/testctrl/svc/types/component.go
+++ b/testctrl/svc/types/component.go
@@ -10,17 +10,17 @@ import (
 // Component represents a dependency for a session. Benchmarks tend to have three components: a
 // driver, server and client. Each component can have many identical replicas.
 type Component struct {
-	name      string
-	container string
-	kind      ComponentKind
-	replicas  int32
-	env       map[string]string
+	name           string
+	containerImage string
+	kind           ComponentKind
+	replicas       int32
+	env            map[string]string
 }
 
-// NewComponent creates a Component instance, given a container, kind and replicas.
+// NewComponent creates a Component instance, given a container image, kind and replicas.
 //
-// The container string should contain the path to a docker image in a registry, versioned by an
-// explicit tag or hash. Replicas should be 1 for drivers and servers. For clients, they may be
+// The container image string should contain the path to a docker image in a registry, versioned by
+// an explicit tag or hash. Replicas should be 1 for drivers and servers. For clients, they may be
 // any positive integer.
 //
 // For example:
@@ -33,12 +33,12 @@ type Component struct {
 //
 //     // Container uses "driver" image with hash from GCR
 //     c := NewComponent("gcr.io/grpc-testing/driver@sha256:e4ff8efd7eb62d3a3bb0990f6ff1e9df20da24ebf908d08f49cb83422a232862", DriverComponent, 1)
-func NewComponent(container string, kind ComponentKind, replicas int32) *Component {
+func NewComponent(containerImage string, kind ComponentKind, replicas int32) *Component {
 	return &Component{
-		name:      uuid.New().String(),
-		container: container,
-		kind:      kind,
-		replicas:  replicas,
+		name:           uuid.New().String(),
+		containerImage: containerImage,
+		kind:           kind,
+		replicas:       replicas,
 	}
 }
 
@@ -55,9 +55,9 @@ func (c *Component) ResourceName() string {
 	return fmt.Sprintf("components/%s", c.Name())
 }
 
-// Container returns the name of a docker image and tag which contains the required component.
-func (c *Component) Container() string {
-	return c.container
+// ContainerImage returns the name of a docker image and tag which contains the required component.
+func (c *Component) ContainerImage() string {
+	return c.containerImage
 }
 
 // Kind returns the type of component.

--- a/testctrl/svc/types/component_test.go
+++ b/testctrl/svc/types/component_test.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	pb "github.com/grpc/grpc/testctrl/genproto/testctrl/svc"
+	"testing"
+)
+
+// TestComponentKindProto checks that the Proto method on the ComponentKind converts to the correct
+// enum value in the protobuf generated code.
+func TestComponentKindProto(t *testing.T) {
+	expected := map[ComponentKind]pb.Component_Kind{
+		DriverComponent: pb.Component_DRIVER,
+		ClientComponent: pb.Component_CLIENT,
+		ServerComponent: pb.Component_SERVER,
+	}
+
+	for k, v := range expected {
+		if k.Proto() != v {
+			t.Errorf("ComponentKind incorrectly converted to proto: expected %s but got %s", v.String(), k.String())
+		}
+	}
+}
+
+// TestComponentKindFromProto checks that the enum values in the protobuf generated code convert to
+// the correct ComponentKind values.
+func TestComponentKindFromProto(t *testing.T) {
+	expected := map[pb.Component_Kind]ComponentKind{
+		pb.Component_DRIVER: DriverComponent,
+		pb.Component_CLIENT: ClientComponent,
+		pb.Component_SERVER: ServerComponent,
+	}
+
+	for k, v := range expected {
+		if ComponentKindFromProto(k) != v {
+			t.Errorf("Proto incorrectly converted to ComponentKind: expected %s but got %s", v.String(), k.String())
+		}
+	}
+}

--- a/testctrl/svc/types/doc.go
+++ b/testctrl/svc/types/doc.go
@@ -1,0 +1,2 @@
+// Package types contains data types that are shared across the different packages of testctrl.
+package types

--- a/testctrl/svc/types/event.go
+++ b/testctrl/svc/types/event.go
@@ -13,8 +13,8 @@ import (
 //
 // Event instances can be created through the constructor or through a literal. The constructor,
 // NewEvent, provides several conveniences.  First, it sets the Time to time.Now. Second, it accepts
-// a Namer for the subject. This allows events to be created using the syntactic sugar of subject
-// objects themselves.
+// a ResourceNamer for the subject. This allows events to be created using the syntactic sugar of
+// subject objects themselves.
 type Event struct {
 	// SubjectName is the string representation of the object this event describes. For example, a
 	// specific session "xyz" may have the subject name of "testSessions/xyz". The format of the
@@ -33,11 +33,11 @@ type Event struct {
 }
 
 // NewEvent instantiates an Event struct, setting its Timestamp to now and its SubjectName to the
-// result of Name method on the Namer. It expects a message, since supplying one can provide more
-// context in an unstructured format.
-func NewEvent(subject Namer, k EventKind, messageFmt string, args ...interface{}) Event {
+// result of Name method on the ResourceNamer. It expects a message, since supplying one can provide
+// more context in an unstructured format.
+func NewEvent(subject ResourceNamer, k EventKind, messageFmt string, args ...interface{}) Event {
 	return Event{
-		SubjectName: subject.Name(),
+		SubjectName: subject.ResourceName(),
 		Kind:        k,
 		Time:        time.Now(),
 		Message:     fmt.Sprintf(messageFmt, args...),

--- a/testctrl/svc/types/event.go
+++ b/testctrl/svc/types/event.go
@@ -1,0 +1,120 @@
+package types
+
+import (
+	"fmt"
+	"time"
+
+	pb "github.com/grpc/grpc/testctrl/genproto/testctrl/svc"
+)
+
+// Event represents an action at a specific point in time on a subject. Likely, the subject is a
+// Session or Component. Events are designed to be chained together, creating a log of all
+// significant points in time.
+//
+// Event instances can be created through the constructor or through a literal. The constructor,
+// NewEvent, provides several conveniences.  First, it sets the Time to time.Now. Second, it accepts
+// a Namer for the subject. This allows events to be created using the syntactic sugar of subject
+// objects themselves.
+type Event struct {
+	// SubjectName is the string representation of the object this event describes. For example, a
+	// specific session "xyz" may have the subject name of "testSessions/xyz". The format of the
+	// string is implementation specific.
+	SubjectName string
+
+	// Kind is the type of event.
+	Kind EventKind
+
+	// Time is the point in time when the event was noticed.
+	Time time.Time
+
+	// Message is additional, unstructured information in a string. For example, it may describe
+	// inputs and and the error message with a ErrorEvent.
+	Message string
+}
+
+// NewEvent instantiates an Event struct, setting its Timestamp to now and its SubjectName to the
+// result of Name method on the Namer. It expects a message, since supplying one can provide more
+// context in an unstructured format.
+func NewEvent(subject Namer, k EventKind, messageFmt string, args ...interface{}) Event {
+	return Event{
+		SubjectName: subject.Name(),
+		Kind:        k,
+		Time:        time.Now(),
+		Message:     fmt.Sprintf(messageFmt, args...),
+	}
+}
+
+// EventKind specifies the type of event. For example, an event could be created for a fatal error or
+// a session is waiting in the queue.
+type EventKind int32
+
+const (
+	// InternalEvent represents a problem in the infrastructure, service or controller itself. It does
+	// not pertain to a session or component. If encountered, file a bug with its particular message.
+	InternalEvent EventKind = iota
+
+	// QueueEvent signals that a session is waiting for resources to run.
+	QueueEvent
+
+	// AcceptEvent indicates that an executor has been assigned to provision and monitor the session;
+	// however, work has not yet begun on the event's subject.
+	AcceptEvent
+
+	// ProvisionEvent means executors have begun reserving and configuring the subject. This may take
+	// a while to complete.
+	ProvisionEvent
+
+	// RunEvent indicates the subject is responding with a healthy signal. However, this does not
+	// verify that it is running the tests.
+	RunEvent
+
+	// DoneEvent conveys the subject has terminated as expected. It does not indicate that the tests
+	// were successful or results were recorded.
+	DoneEvent
+
+	// ErrorEvent means something has gone irrecoverably wrong with the event's subject.
+	ErrorEvent
+)
+
+// EventKindFromProto takes the generated protobuf enum type and safely converts it into an EventKind.
+// It ensures the string representations are equivalent, even if values change.
+func EventKindFromProto(p pb.Event_Kind) EventKind {
+	return eventKindStringToConstMap[p.String()]
+}
+
+// String returns the string representation of the EventKind.
+func (k EventKind) String() string {
+	return eventKindConstToStringMap[k]
+}
+
+// Proto converts the EventKind enum into the generated protobuf enum. It ensures the string
+// representations are equivalent, even if values change.
+func (k EventKind) Proto() pb.Event_Kind {
+	return pb.Event_Kind(pb.Event_Kind_value[k.String()])
+}
+
+var eventKindStringToConstMap = map[string]EventKind{
+	"INTERNAL":  InternalEvent,
+	"QUEUE":     QueueEvent,
+	"ACCEPT":    AcceptEvent,
+	"PROVISION": ProvisionEvent,
+	"RUN":       RunEvent,
+	"DONE":      DoneEvent,
+	"ERROR":     ErrorEvent,
+}
+
+var eventKindConstToStringMap = map[EventKind]string{
+	InternalEvent:  "INTERNAL",
+	QueueEvent:     "QUEUE",
+	AcceptEvent:    "ACCEPT",
+	ProvisionEvent: "PROVISION",
+	RunEvent:       "RUN",
+	DoneEvent:      "DONE",
+	ErrorEvent:     "ERROR",
+}
+
+// EventRecorder implementations save events to a storage medium.
+type EventRecorder interface {
+	// Record saves an event.
+	Record(e Event)
+}

--- a/testctrl/svc/types/event.go
+++ b/testctrl/svc/types/event.go
@@ -49,9 +49,11 @@ func NewEvent(subject ResourceNamer, k EventKind, messageFmt string, args ...int
 type EventKind int32
 
 const (
-	// InternalEvent represents a problem in the infrastructure, service or controller itself. It does
-	// not pertain to a session or component. If encountered, file a bug with its particular message.
-	InternalEvent EventKind = iota
+	_ EventKind = iota
+
+	// InternalErrorEvent represents a problem in the infrastructure, service or controller itself. It
+	// does not pertain to a session or component. If encountered, file a bug with its particular message.
+	InternalErrorEvent
 
 	// QueueEvent signals that a session is waiting for resources to run.
 	QueueEvent
@@ -94,17 +96,17 @@ func (k EventKind) Proto() pb.Event_Kind {
 }
 
 var eventKindStringToConstMap = map[string]EventKind{
-	"INTERNAL":  InternalEvent,
-	"QUEUE":     QueueEvent,
-	"ACCEPT":    AcceptEvent,
-	"PROVISION": ProvisionEvent,
-	"RUN":       RunEvent,
-	"DONE":      DoneEvent,
-	"ERROR":     ErrorEvent,
+	"INTERNAL_ERROR": InternalErrorEvent,
+	"QUEUE":          QueueEvent,
+	"ACCEPT":         AcceptEvent,
+	"PROVISION":      ProvisionEvent,
+	"RUN":            RunEvent,
+	"DONE":           DoneEvent,
+	"ERROR":          ErrorEvent,
 }
 
 var eventKindConstToStringMap = map[EventKind]string{
-	InternalEvent:  "INTERNAL",
+	InternalErrorEvent:  "INTERNAL_ERROR",
 	QueueEvent:     "QUEUE",
 	AcceptEvent:    "ACCEPT",
 	ProvisionEvent: "PROVISION",

--- a/testctrl/svc/types/event_test.go
+++ b/testctrl/svc/types/event_test.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	pb "github.com/grpc/grpc/testctrl/genproto/testctrl/svc"
+	"testing"
+)
+
+// TestEventKindProto checks that the Proto method on the EventKind converts to the correct enum value
+// in the protobuf generated code.
+func TestEventKindProto(t *testing.T) {
+	expected := map[EventKind]pb.Event_Kind{
+		InternalEvent:  pb.Event_INTERNAL,
+		QueueEvent:     pb.Event_QUEUE,
+		AcceptEvent:    pb.Event_ACCEPT,
+		ProvisionEvent: pb.Event_PROVISION,
+		RunEvent:       pb.Event_RUN,
+		DoneEvent:      pb.Event_DONE,
+		ErrorEvent:     pb.Event_ERROR,
+	}
+
+	for k, v := range expected {
+		if k.Proto() != v {
+			t.Errorf("EventKind incorrectly converted to proto: expected %s but got %s", v.String(), k.String())
+		}
+	}
+}
+
+// TestEventKindFromProto checks that the enum values in the protobuf generated code convert to the
+// correct EventKind values.
+func TestEventKindFromProto(t *testing.T) {
+	expected := map[pb.Event_Kind]EventKind{
+		pb.Event_INTERNAL:  InternalEvent,
+		pb.Event_QUEUE:     QueueEvent,
+		pb.Event_ACCEPT:    AcceptEvent,
+		pb.Event_PROVISION: ProvisionEvent,
+		pb.Event_RUN:       RunEvent,
+		pb.Event_DONE:      DoneEvent,
+		pb.Event_ERROR:     ErrorEvent,
+	}
+
+	for k, v := range expected {
+		if EventKindFromProto(k) != v {
+			t.Errorf("Proto incorrectly converted to EventKind: expected %s but got %s", v.String(), k.String())
+		}
+	}
+}

--- a/testctrl/svc/types/event_test.go
+++ b/testctrl/svc/types/event_test.go
@@ -1,21 +1,22 @@
 package types
 
 import (
-	pb "github.com/grpc/grpc/testctrl/genproto/testctrl/svc"
 	"testing"
+
+	pb "github.com/grpc/grpc/testctrl/genproto/testctrl/svc"
 )
 
 // TestEventKindProto checks that the Proto method on the EventKind converts to the correct enum value
 // in the protobuf generated code.
 func TestEventKindProto(t *testing.T) {
 	expected := map[EventKind]pb.Event_Kind{
-		InternalEvent:  pb.Event_INTERNAL,
-		QueueEvent:     pb.Event_QUEUE,
-		AcceptEvent:    pb.Event_ACCEPT,
-		ProvisionEvent: pb.Event_PROVISION,
-		RunEvent:       pb.Event_RUN,
-		DoneEvent:      pb.Event_DONE,
-		ErrorEvent:     pb.Event_ERROR,
+		InternalErrorEvent: pb.Event_INTERNAL_ERROR,
+		QueueEvent:         pb.Event_QUEUE,
+		AcceptEvent:        pb.Event_ACCEPT,
+		ProvisionEvent:     pb.Event_PROVISION,
+		RunEvent:           pb.Event_RUN,
+		DoneEvent:          pb.Event_DONE,
+		ErrorEvent:         pb.Event_ERROR,
 	}
 
 	for k, v := range expected {
@@ -29,13 +30,13 @@ func TestEventKindProto(t *testing.T) {
 // correct EventKind values.
 func TestEventKindFromProto(t *testing.T) {
 	expected := map[pb.Event_Kind]EventKind{
-		pb.Event_INTERNAL:  InternalEvent,
-		pb.Event_QUEUE:     QueueEvent,
-		pb.Event_ACCEPT:    AcceptEvent,
-		pb.Event_PROVISION: ProvisionEvent,
-		pb.Event_RUN:       RunEvent,
-		pb.Event_DONE:      DoneEvent,
-		pb.Event_ERROR:     ErrorEvent,
+		pb.Event_INTERNAL_ERROR: InternalErrorEvent,
+		pb.Event_QUEUE:          QueueEvent,
+		pb.Event_ACCEPT:         AcceptEvent,
+		pb.Event_PROVISION:      ProvisionEvent,
+		pb.Event_RUN:            RunEvent,
+		pb.Event_DONE:           DoneEvent,
+		pb.Event_ERROR:          ErrorEvent,
 	}
 
 	for k, v := range expected {

--- a/testctrl/svc/types/namer.go
+++ b/testctrl/svc/types/namer.go
@@ -1,0 +1,7 @@
+package types
+
+// Namer is any type that can assign a string that identifies a specific instance.
+type Namer interface {
+	// Name returns a string with a name for its receiver.
+	Name() string
+}

--- a/testctrl/svc/types/namer.go
+++ b/testctrl/svc/types/namer.go
@@ -1,7 +1,0 @@
-package types
-
-// Namer is any type that can assign a string that identifies a specific instance.
-type Namer interface {
-	// Name returns a string with a name for its receiver.
-	Name() string
-}

--- a/testctrl/svc/types/resource_namer.go
+++ b/testctrl/svc/types/resource_namer.go
@@ -1,0 +1,7 @@
+package types
+
+// ResourceNamer is any type that can assign a string that identifies a specific resource.
+type ResourceNamer interface {
+	// ResourceName returns a string with a name for its receiver.
+	ResourceName() string
+}

--- a/testctrl/svc/types/session.go
+++ b/testctrl/svc/types/session.go
@@ -1,0 +1,55 @@
+package types
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/grpc/grpc/testctrl/genproto/grpc/testing"
+)
+
+// Session is a test scenario, its components and metdata.
+type Session struct {
+	name       string
+	driver     *Component
+	workers    []*Component
+	scenario   *pb.Scenario
+	createTime time.Time
+}
+
+// NewSession creates a Session, assigning it a unique name.
+func NewSession(driver *Component, workers []*Component, scenario *pb.Scenario) *Session {
+	return &Session{
+		name:       fmt.Sprintf("testSessions/%s", uuid.New().String()),
+		driver:     driver,
+		workers:    workers,
+		scenario:   scenario,
+		createTime: time.Now(),
+	}
+}
+
+// Name returns the globally unique name that identifies this Session instance.
+func (t *Session) Name() string {
+	return t.name
+}
+
+// Driver returns the Session's driver component.
+func (t *Session) Driver() *Component {
+	return t.driver
+}
+
+// Workers returns the slice of the Session's worker components.
+func (t *Session) Workers() []*Component {
+	return t.workers
+}
+
+// Scenario returns the raw test scenario protobuf. The scenario is not parsed into
+// implementation-specific types, because the service is designed to know nothing about the tests.
+func (t *Session) Scenario() *pb.Scenario {
+	return t.scenario
+}
+
+// CreateTime returns the time that the Session was instantiated.
+func (t *Session) CreateTime() time.Time {
+	return t.createTime
+}

--- a/testctrl/svc/types/session.go
+++ b/testctrl/svc/types/session.go
@@ -20,7 +20,7 @@ type Session struct {
 // NewSession creates a Session, assigning it a unique name.
 func NewSession(driver *Component, workers []*Component, scenario *pb.Scenario) *Session {
 	return &Session{
-		name:       fmt.Sprintf("testSessions/%s", uuid.New().String()),
+		name:       uuid.New().String(),
 		driver:     driver,
 		workers:    workers,
 		scenario:   scenario,
@@ -31,6 +31,12 @@ func NewSession(driver *Component, workers []*Component, scenario *pb.Scenario) 
 // Name returns the globally unique name that identifies this Session instance.
 func (t *Session) Name() string {
 	return t.name
+}
+
+// ResourceName returns the name the session prefixed with `sessions/`. This value should be the
+// name that is shared with a consumer of the API.
+func (t *Session) ResourceName() string {
+	return fmt.Sprintf("sessions/%s", t.name)
 }
 
 // Driver returns the Session's driver component.

--- a/testctrl/svc/types/session.go
+++ b/testctrl/svc/types/session.go
@@ -49,6 +49,16 @@ func (t *Session) Workers() []*Component {
 	return t.workers
 }
 
+// ClientWorkers returns the slice of all the workers with a kind of ClientComponent.
+func (t *Session) ClientWorkers() []*Component {
+	return t.filterWorkers(ClientComponent)
+}
+
+// ServerWorkers returns the slice of all the workers with a kind of ServerComponent.
+func (t *Session) ServerWorkers() []*Component {
+	return t.filterWorkers(ServerComponent)
+}
+
 // Scenario returns the raw test scenario protobuf. The scenario is not parsed into
 // implementation-specific types, because the service is designed to know nothing about the tests.
 func (t *Session) Scenario() *pb.Scenario {
@@ -58,4 +68,17 @@ func (t *Session) Scenario() *pb.Scenario {
 // CreateTime returns the time that the Session was instantiated.
 func (t *Session) CreateTime() time.Time {
 	return t.createTime
+}
+
+// filterWorkers returns a slice with only a specific ComponentKind.
+func (t *Session) filterWorkers(k ComponentKind) []*Component {
+	var cs []*Component
+
+	for _, w := range t.workers {
+		if w.Kind() == k {
+			cs = append(cs, w)
+		}
+	}
+
+	return cs
 }

--- a/testctrl/svc/types/session_test.go
+++ b/testctrl/svc/types/session_test.go
@@ -1,0 +1,33 @@
+// Package types_test is used to avoid a circular dependency, since these tests use the builders
+// from the subpackage and the types package itself.
+package types_test
+
+import (
+  "reflect"
+  "testing"
+
+  "github.com/grpc/grpc/testctrl/svc/types"
+  "github.com/grpc/grpc/testctrl/svc/types/test"
+)
+
+func TestSessionFilterWorkers(t *testing.T) {
+  driver := test.NewComponentBuilder().SetKind(types.DriverComponent).Build()
+  client := test.NewComponentBuilder().SetKind(types.ClientComponent).Build()
+  server := test.NewComponentBuilder().SetKind(types.ServerComponent).Build()
+  session := test.NewSessionBuilder().SetComponents(driver, client, server).Build()
+
+  cases := []struct{
+  	methodName string
+    filterFunc func() []*types.Component
+    expected []*types.Component
+  }{
+    {"ClientWorkers", session.ClientWorkers, []*types.Component{client}},
+    {"ServerWorkers", session.ServerWorkers, []*types.Component{server}},
+  }
+
+  for _, c := range cases {
+    if results := c.filterFunc(); !reflect.DeepEqual(results, c.expected) {
+      t.Errorf("Session %v included incompatible workers: expected %v but got %v", c.methodName, c.expected, results)
+    }
+  }
+}

--- a/testctrl/svc/types/test/component_builder.go
+++ b/testctrl/svc/types/test/component_builder.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+type ComponentBuilder struct {
+	container string
+	kind types.ComponentKind
+	replicas int32
+	env map[string]string
+}
+
+func NewComponentBuilder() *ComponentBuilder {
+	return &ComponentBuilder{
+		container: "example:latest",
+		kind: types.ClientComponent,
+		replicas: 1,
+	}
+}
+
+func (cb *ComponentBuilder) Build() *types.Component {
+	c := types.NewComponent(cb.container, cb.kind, cb.replicas)
+	for k, v := range cb.env {
+		c.SetEnv(k, v)
+	}
+	return c
+}
+
+func (cb *ComponentBuilder) SetContainer(c string) *ComponentBuilder {
+	cb.container = c
+	return cb
+}
+
+func (cb *ComponentBuilder) SetEnv(key, value string) *ComponentBuilder {
+	cb.env[key] = value
+	return cb
+}
+
+func (cb *ComponentBuilder) SetKind(k types.ComponentKind) *ComponentBuilder {
+	cb.kind = k
+	return cb
+}
+
+func (cb *ComponentBuilder) SetReplicas(r int32) *ComponentBuilder {
+	cb.replicas = r
+	return cb
+}

--- a/testctrl/svc/types/test/session_builder.go
+++ b/testctrl/svc/types/test/session_builder.go
@@ -1,0 +1,52 @@
+package test
+
+import (
+	"github.com/grpc/grpc/testctrl/svc/types"
+	pb "github.com/grpc/grpc/testctrl/genproto/grpc/testing"
+)
+
+type SessionBuilder struct {
+	driver *types.Component
+	workers []*types.Component
+	scenario *pb.Scenario
+}
+
+func NewSessionBuilder() *SessionBuilder {
+	return &SessionBuilder{
+		driver: NewComponentBuilder().SetKind(types.DriverComponent).Build(),
+		workers: []*types.Component{},
+		scenario: nil,
+	}
+}
+
+func (sb *SessionBuilder) AddWorkers(cs ...*types.Component) *SessionBuilder {
+	for _, c := range cs {
+		sb.workers = append(sb.workers, c)
+	}
+	return sb
+}
+
+func (sb *SessionBuilder) Build() *types.Session {
+	return types.NewSession(sb.driver, sb.workers, sb.scenario)
+}
+
+func (sb *SessionBuilder) SetComponents(cs ...*types.Component) *SessionBuilder {
+	for _, c := range cs {
+		if c.Kind() == types.DriverComponent {
+			sb.driver = c
+		} else {
+			sb.AddWorkers(c)
+		}
+	}
+	return sb
+}
+
+func (sb *SessionBuilder) SetDriver(c *types.Component) *SessionBuilder {
+	sb.driver = c
+	return sb
+}
+
+func (sb *SessionBuilder) SetScenario(scen *pb.Scenario) *SessionBuilder {
+	sb.scenario = scen
+	return sb
+}


### PR DESCRIPTION
This commit introduces a types package, which contains the data types that will be shared across other svc subpackages. These types include a Component, Event and Session.

In addition, a ResourceNamer interface is defined for convenience. It defines a single method `ResourceName` which returns a string representation of an instance of the implementing type. This allows events to be created using Component or Session instances more cleanly.