### PR TITLE
Add SpecBuilder to create kubernetes resource specs

### DIFF
--- a/testctrl/svc/orch/spec_builder.go
+++ b/testctrl/svc/orch/spec_builder.go
@@ -1,0 +1,123 @@
+package orch
+
+import (
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+const driverPort int32 = 10000
+const serverPort int32 = 10010
+var zero int32 = 0
+
+// SpecBuilder creates valid Kubernetes specs for components.
+type SpecBuilder struct {
+	session *types.Session
+	component *types.Component
+}
+
+// NewSpecBuilder creates a SpecBuilder instance for a specific session and component.
+func NewSpecBuilder(s *types.Session, c *types.Component) *SpecBuilder {
+	return &SpecBuilder{s, c}
+}
+
+// Containers lists the containers available in each pod the deployment manages.  Since sidecars
+// are not used for load testing, there will only be one container in the returned slice.
+func (sb *SpecBuilder) Containers() []apiv1.Container {
+	return []apiv1.Container{
+		{
+			Name:  sb.component.Name(),
+			Image: sb.component.ContainerImage(),
+			Ports: sb.ContainerPorts(),
+		},
+	}
+}
+
+// ContainerPorts specifies the ingress ports (TCP) on the pods.  For the driver and client, this
+// is only the DriverPort. For the server, the ServerPort is included.
+func (sb *SpecBuilder) ContainerPorts() []apiv1.ContainerPort {
+	var ports []apiv1.ContainerPort
+
+	ports = append(ports, apiv1.ContainerPort{
+		Name:          "driver-port",
+		Protocol:      apiv1.ProtocolTCP,
+		ContainerPort: driverPort,
+	})
+
+	if sb.component.Kind() == types.ServerComponent {
+		ports = append(ports, apiv1.ContainerPort{
+			Name:          "server-port",
+			Protocol:      apiv1.ProtocolTCP,
+			ContainerPort: serverPort,
+		})
+	}
+
+	return ports
+}
+
+// Deployment builds a Kubernetes deployment object.
+func (sb *SpecBuilder) Deployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: sb.ObjectMeta(),
+		Spec: sb.DeploymentSpec(),
+	}
+}
+
+// DeploymentSpec builds a Kubernetes deployment spec object.
+func (sb *SpecBuilder) DeploymentSpec() appsv1.DeploymentSpec{
+	replicas := sb.component.Replicas()
+
+	return appsv1.DeploymentSpec{
+		Replicas: &replicas,
+		Selector: &metav1.LabelSelector{
+			MatchLabels: sb.Labels(),
+		},
+		Strategy: appsv1.DeploymentStrategy{
+			// disable rolling updates
+			Type: "Recreate",
+			RollingUpdate: nil,
+		},
+		RevisionHistoryLimit: &zero,  // disable rollbacks
+		Template: sb.PodTemplateSpec(),
+	}
+}
+
+// ObjectMeta returns the metadata that should be set on all resources created for a specific
+// component. Most importantly, it includes the component's name and necessary labels.
+func (sb *SpecBuilder) ObjectMeta() metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:        sb.component.Name(),
+		Labels:      sb.Labels(),
+	}
+}
+
+// Labels returns a map of labels that are added to the resource and controller specs. The
+// following labels accompany all SpecBuilder generated resources:
+//
+//   1. `autogen` set to a value of 1, signifying these resources are automatically generated
+//   2. `session-name` set to the internal name of the current session
+//	 3. `component-name` set to the internal name of the component
+//	 4. `component-kind` set to the kind of component (e.g. "driver")
+func (sb *SpecBuilder) Labels() map[string]string {
+	return map[string]string{
+		"autogen": "1",
+		"session-name": sb.session.Name(),
+		"component-name": sb.component.Name(),
+		"component-kind": strings.ToLower(sb.component.Kind().String()),
+	}
+}
+
+// PodTemplateSpec builds a Kubernetes podspec for the deployment to manage.
+func (sb *SpecBuilder) PodTemplateSpec() apiv1.PodTemplateSpec {
+	return apiv1.PodTemplateSpec{
+		ObjectMeta: sb.ObjectMeta(),
+		Spec: apiv1.PodSpec{
+			Containers: sb.Containers(),
+		},
+	}
+}
+

--- a/testctrl/svc/orch/spec_builder_test.go
+++ b/testctrl/svc/orch/spec_builder_test.go
@@ -1,0 +1,145 @@
+package orch
+
+import (
+	"reflect"
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+	"github.com/grpc/grpc/testctrl/svc/types/test"
+)
+
+func TestSpecBuilderContainers(t *testing.T) {
+	image := "debian:jessie"
+	component := test.NewComponentBuilder().SetContainer(image).Build()
+	session := test.NewSessionBuilder().SetComponents(component).Build()
+	sb := NewSpecBuilder(session, component)
+	containers := sb.Containers()
+
+	if len(containers) < 1 {
+		t.Fatalf("SpecBuilder Containers did not specify any containers; expected '%s'", image)
+	}
+
+	if actualImage := containers[0].Image; actualImage != image {
+		t.Errorf("SpecBuilder Containers did not correctly set the container image; expected '%s' but got '%s'", image, actualImage)
+	}
+}
+
+func TestSpecBuilderContainerPorts(t *testing.T) {
+	cases := []struct {
+		kind types.ComponentKind
+		ports []int32
+	}{
+		{types.DriverComponent, []int32{driverPort}},
+		{types.ClientComponent, []int32{driverPort}},
+		{types.ServerComponent, []int32{driverPort, serverPort}},
+	}
+
+	var containerPortSlice = func(cps []apiv1.ContainerPort) []int32 {
+		var ports []int32
+
+		for _, port := range cps {
+			ports = append(ports, port.ContainerPort)
+		}
+
+		return ports
+	}
+
+	for _, c := range cases {
+		component := test.NewComponentBuilder().SetKind(c.kind).Build()
+		session := test.NewSessionBuilder().SetComponents(component).Build()
+		sb := NewSpecBuilder(session, component)
+		ports := containerPortSlice(sb.ContainerPorts())
+
+		if !reflect.DeepEqual(ports, c.ports) {
+			t.Errorf("SpecBuilder ContainerPorts does not contain the correct ports for %s; expected %v but got %v", c.kind, c.ports, ports)
+		}
+	}
+}
+
+
+func TestSpecBuilderDeploymentSpec(t *testing.T) {
+	// Check that replicas are properly set
+	component := test.NewComponentBuilder().SetReplicas(3).Build()
+	session := test.NewSessionBuilder().SetComponents(component).Build()
+	sb := NewSpecBuilder(session, component)
+
+	replicaPtr := sb.DeploymentSpec().Replicas
+	if replicaPtr == nil {
+		t.Errorf("SpecBuilder DeploymentSpec did not specify a number of component replicas; expected '%v'", component.Replicas())
+	} else if *replicaPtr != component.Replicas() {
+		t.Errorf("SpecBuilder DeploymentSpec did not set the correct number of component replicas; expected '%v' but got '%v'", component.Replicas(), *replicaPtr)
+	}
+
+	// Check that the selector includes all labels
+	component = test.NewComponentBuilder().Build()
+	session = test.NewSessionBuilder().SetComponents(component).Build()
+	sb = NewSpecBuilder(session, component)
+	matchLabels := sb.DeploymentSpec().Selector.MatchLabels
+
+	if !reflect.DeepEqual(matchLabels, sb.Labels()) {
+		t.Errorf("SpecBuilder DeploymentSpec did not match correct pods on deployment; expected labels '%v' but got '%v'", sb.Labels(), matchLabels)
+	}
+}
+
+func TestSpecBuilderLabels(t *testing.T) {
+	// Check that spec contains a 'session-name' label
+	session := test.NewSessionBuilder().Build()
+	sb := NewSpecBuilder(session, test.NewComponentBuilder().Build())
+	labels := sb.Labels()
+
+	if sessionName := labels["session-name"]; sessionName != session.Name() {
+		t.Errorf("SpecBuilder Labels generated incorrect 'session-name' label; expected '%s' but got '%v'", session.Name(), sessionName)
+	}
+
+	// Check the spec contains 'component-name' label
+	component := test.NewComponentBuilder().Build()
+	sb = NewSpecBuilder(test.NewSessionBuilder().Build(), component)
+	labels = sb.Labels()
+
+	if componentName := labels["component-name"]; componentName != component.Name() {
+		t.Errorf("SpecBuilder Labels generated incorrect 'component-name' label; expected '%s' but got '%v'", component.Name(), componentName)
+	}
+
+	// Check the spec constains 'component-kind' label
+	kindCases := []struct {
+		kind       types.ComponentKind
+		labelValue string
+	}{
+		{types.DriverComponent, "driver"},
+		{types.ClientComponent, "client"},
+		{types.ServerComponent, "server"},
+	}
+
+	for _, c := range kindCases {
+		component := test.NewComponentBuilder().SetKind(c.kind).Build()
+		session := test.NewSessionBuilder().SetComponents(component).Build()
+		sb := NewSpecBuilder(session, component)
+		labels := sb.Labels()
+
+		if kind := labels["component-kind"]; kind != c.labelValue {
+			t.Errorf("SpecBuilder Labels generated incorrect 'component-kind' label for %s component; expected '%s' but got '%v'", c.kind.String(), c.labelValue, kind)
+		}
+	}
+
+	// Check that the 'autogen' label exists, signifying that this resource was automatically generated
+	sb = NewSpecBuilder(test.NewSessionBuilder().Build(), test.NewComponentBuilder().Build())
+	labels = sb.Labels()
+
+	if autogen := labels["autogen"]; autogen != "1" {
+		t.Errorf("SpecBuilder Labels missing 'autogen' label to signify generated component")
+	}
+}
+
+func TestSpecBuilderObjectMeta(t *testing.T) {
+	component := test.NewComponentBuilder().Build()
+	componentName := component.Name()
+	session := test.NewSessionBuilder().SetComponents(component).Build()
+	sb := NewSpecBuilder(session, component)
+
+	if resourceName := sb.ObjectMeta().Name; resourceName != componentName {
+		t.Errorf("SpecBuilder ObjectMeta did not set the K8s resource name to the component name; expected '%s' but got '%s'", componentName, resourceName)
+	}
+}
+


### PR DESCRIPTION
Kubernetes relies on a declarative API objects called specs. These declare the desired state of a resource. This change adds a builder to ease in creating this specs using our custom data types.