### PR TITLE
Add controller skeleton

### DIFF
--- a/testctrl/svc/orch/controller.go
+++ b/testctrl/svc/orch/controller.go
@@ -1,0 +1,38 @@
+package orch
+
+import (
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+// Controller manages active and idle sessions, as well as, communications with the Kubernetes API.
+type Controller struct {
+	clientset   *kubernetes.Clientset
+}
+
+// NewController constructs a Controller instance with a Kubernetes Clientset. This allows the
+// controller to communicate with the Kubernetes API.
+func NewController(clientset *kubernetes.Clientset) *Controller {
+	c := &Controller{clientset}
+	return c
+}
+
+// Schedule adds a session to the controller's queue. It will remain in the queue until there are
+// sufficient resources for processing and monitoring.
+func (c *Controller) Schedule(s *types.Session) error {
+	return nil
+}
+
+// Start spawns goroutines to monitor the Kubernetes cluster for updates and to process a limited
+// number of sessions at a time.
+func (c *Controller) Start() error {
+	return nil
+}
+
+// Stop safely terminates all goroutines spawned by the call to Start. It returns immediately, but
+// it allows the active sessions to finish before terminating goroutines.
+func (c *Controller) Stop() error {
+	return nil
+}
+

--- a/testctrl/svc/scheduling_server.go
+++ b/testctrl/svc/scheduling_server.go
@@ -18,10 +18,20 @@ import (
 	"context"
 
 	svcPb "github.com/grpc/grpc/testctrl/proto/scheduling/v1"
+	"github.com/grpc/grpc/testctrl/svc/types"
+
 	lrPb "google.golang.org/genproto/googleapis/longrunning"
 )
 
+// Scheduler is a single method interface for queueing sessions.
+type Scheduler interface {
+	// Schedule enqueues a session, returning any immediate error. Infrastructure and
+	// test runtime errors will not be returned.
+	Schedule(s *types.Session) error
+}
+
 type SchedulingServer struct {
+	Scheduler Scheduler
 }
 
 func (s *SchedulingServer) StartTestSession(ctx context.Context, req *svcPb.StartTestSessionRequest) (*lrPb.Operation, error) {


### PR DESCRIPTION
This commit adds a skeleton for the controller that is in progress, also defining a Scheduler interface which it will implement. This allows work to continue on the service while the controller is incomplete.
