### PR TITLE
Switch to glog for logging

### DIFF
--- a/testctrl/README.md
+++ b/testctrl/README.md
@@ -48,11 +48,11 @@ to locate test results or error logs upon completion.
 
 To start the service without containers on your local machine, run:
 
-    $ go run ./cmd/svc/main.go
+    $ go run ./cmd/svc/main.go --alsologtostderr
 
 You can force the service to use a different port with the flag `-port`:
 
-    $ go run ./cmd/svc/main.go -- -port=4044
+    $ go run ./cmd/svc/main.go -port=4044 --alsologtostderr
 
 When the service is started, it looks for an `$APP_ENV` environment variable.
 

--- a/testctrl/README.md
+++ b/testctrl/README.md
@@ -48,11 +48,11 @@ to locate test results or error logs upon completion.
 
 To start the service without containers on your local machine, run:
 
-    $ go run ./cmd/svc/main.go --alsologtostderr
+    $ go run ./cmd/svc/main.go -alsologtostderr
 
 You can force the service to use a different port with the flag `-port`:
 
-    $ go run ./cmd/svc/main.go -port=4044 --alsologtostderr
+    $ go run ./cmd/svc/main.go -port=4044 -alsologtostderr
 
 When the service is started, it looks for an `$APP_ENV` environment variable.
 

--- a/testctrl/go.mod
+++ b/testctrl/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/codeblooded/grpc-proto v0.0.0-20200313013133-528fc9e42025
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.5
 	github.com/google/uuid v1.1.1
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect


### PR DESCRIPTION
The service relied on the standard library log library. This was found to be too minimal, because it did not support levels. This change moves the project to use glog. The [glog] project is a port of Google's C++ logging library of the same name. It is used as the logging library for grpc-go.

See glog docs at [pkg.go.dev/github.com/golang/glog](https://pkg.go.dev/github.com/golang/glog?tab=doc)

[glog]: https://github.com/golang/glog