### PR TITLE
Add timeout parameter to Controller Stop method

### DIFF
--- a/testctrl/cmd/svc/main.go
+++ b/testctrl/cmd/svc/main.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 
@@ -63,6 +64,7 @@ func setupDevEnv(grpcServer *grpc.Server) *kubernetes.Clientset {
 
 func main() {
 	port := flag.Int("port", 50051, "Port to start the service.")
+	shutdownTimeout := flag.Duration("shutdownTimeout", 5*time.Minute, "Time alloted to a graceful shutdown.")
 	flag.Parse()
 	defer glog.Flush()
 
@@ -84,7 +86,7 @@ func main() {
 		glog.Fatalf("unable to start orchestration controller: %v", err)
 	}
 
-	defer controller.Stop()
+	defer controller.Stop(*shutdownTimeout)
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {

--- a/testctrl/svc/orch/controller.go
+++ b/testctrl/svc/orch/controller.go
@@ -1,6 +1,8 @@
 package orch
 
 import (
+	"time"
+
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/grpc/grpc/testctrl/svc/types"
@@ -30,9 +32,12 @@ func (c *Controller) Start() error {
 	return nil
 }
 
-// Stop safely terminates all goroutines spawned by the call to Start. It returns immediately, but
-// it allows the active sessions to finish before terminating goroutines.
-func (c *Controller) Stop() error {
+// Stop attempts to terminate all orchestration goroutines spawned by a call to Start. It waits for
+// executors to exit. Then, it kills the kubernetes watcher.
+//
+// If the timeout is reached before executors exit, an error is returned. The kubernetes watcher is
+// still terminated. Any sessions running on the unterminated executors will likely fail.
+func (c *Controller) Stop(timeout time.Duration) error {
 	return nil
 }
 


### PR DESCRIPTION
The previous version of the Controller type offered a Stop method that was non-blocking. This was problematic, because watchers should not terminate before all executors have finished monitoring sessions. When a watcher terminates first, the executors will stop receiving kubernetes updates before the session has finished.

This commit switches the Stop function to block with a timeout. It waits for the amount of time specified to permit a graceful shutdown before forcing one. It also introduces a command line flag, `-shutdownTimeout` on the service to adjust this timeout.

While this does not remove the issue, the timeout can be tweaked to mitigate the problem.