### PR TITLE
Add object and health types

### DIFF
--- a/testctrl/svc/orch/health.go
+++ b/testctrl/svc/orch/health.go
@@ -1,0 +1,34 @@
+package orch
+
+// Health indicates the availability or readiness of an object or a set of objects.
+type Health int32
+
+const (
+	// Unknown indicates the health status has not been updated.
+	Unknown Health = iota
+
+	// Unhealthy indicates that the object is not available due an error.
+	Unhealthy
+
+	// Healthy indicates the object is available and appears to be running.
+	Healthy
+
+	// Done indicates the object has terminated with a successful state.
+	Done
+
+	// Failed indicates the object has terminated in an unsuccessful state.
+	Failed
+)
+
+// String returns the string representation of a health constant.
+func (h Health) String() string {
+	return healthConstToStringMap[h]
+}
+
+var healthConstToStringMap = map[Health]string{
+	Unknown:   "unknown",
+	Unhealthy: "unhealthy",
+	Healthy:   "healthy",
+	Done:      "done",
+	Failed:    "failed",
+}

--- a/testctrl/svc/orch/object.go
+++ b/testctrl/svc/orch/object.go
@@ -1,0 +1,227 @@
+package orch
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"k8s.io/api/core/v1"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+// ErrorContainerTerminated indicates that an object's docker container has terminated.
+var ErrorContainerTerminated error
+
+// ErrorContainerTerminating indicates that an object's docker container has begun terminating.
+var ErrorContainerTerminating error
+
+// ErrorContainerCrashed indicates that an object's docker container is in the waiting state, but
+// a crash has been detected.
+var ErrorContainerCrashed error
+
+// ErrorPodFailed indicates that kubernetes marked an object's pod as failed.
+var ErrorPodFailed error
+
+// init, although normally discouraged, is only used to initialize the error variables, since they
+// require the Errorf function from the fmt package.
+func init() {
+	ErrorContainerTerminated = fmt.Errorf("container terminated")
+	ErrorContainerTerminating = fmt.Errorf("container terminating")
+	ErrorContainerCrashed = fmt.Errorf("container crashed")
+	ErrorPodFailed = fmt.Errorf("pod failed")
+}
+
+// Object is a Component coupled with its status, health, and kubernetes pod information. It is
+// designed to be used internally. It should be instantiated with the NewObjects function. All
+// methods are thread-safe.
+type Object struct {
+	component *types.Component
+	podStatus v1.PodStatus
+	health    Health
+	mux       sync.Mutex
+	err       error
+}
+
+// NewObjects is a constructor for an object that takes components as variadic arguments. For each
+// component, it will return exactly one Object instance in the returned slice.
+func NewObjects(cs ...*types.Component) []*Object {
+	var objects []*Object
+
+	for _, component := range cs {
+		objects = append(objects, &Object{
+			component: component,
+		})
+	}
+
+	return objects
+}
+
+// Name provides convenient access to the component name.
+func (o *Object) Name() string {
+	return o.component.Name()
+}
+
+// Component is the component instance that the object wraps.
+func (o *Object) Component() *types.Component {
+	return o.component
+}
+
+// Update modifies a component's health and status by looking for errors in a kubernetes PodStatus.
+func (o *Object) Update(status v1.PodStatus) {
+	var err error
+	phase := status.Phase
+	if phase == v1.PodFailed {
+		err = ErrorPodFailed
+	}
+
+	var cstate containerState
+	if cstatuses := status.ContainerStatuses; len(cstatuses) > 0 {
+		cstatus := &status.ContainerStatuses[0]
+		if wcstate := cstatus.State.Waiting; wcstate != nil {
+			if strings.Compare("CrashLoopBackOff", wcstate.Reason) == 0 {
+				cstate = containerStateCrashWaiting
+				err = ErrorContainerCrashed
+			} else {
+				cstate = containerStateWaiting
+			}
+		} else if cstatus.State.Terminated != nil {
+			cstate = containerStateTerminated
+			err = ErrorContainerTerminated
+		} else if cstatus.LastTerminationState.Terminated != nil {
+			cstate = containerStateTerminating
+			err = ErrorContainerTerminating
+		} else if cstatus.State.Running != nil {
+			cstate = containerStateRunning
+		} else {
+			cstate = containerStateUnknown
+		}
+	}
+
+	o.mux.Lock()
+	defer o.mux.Unlock()
+
+	psm, ok := phaseStateMap[phase]
+	if !ok {
+		o.health = Unknown
+	}
+
+	health, ok := psm[cstate]
+	if ok {
+		o.health = health
+	} else {
+		o.health = Unknown
+	}
+
+	o.podStatus = status
+	if phase != v1.PodSucceeded {
+		o.err = err
+	}
+}
+
+// Health returns the health value that is currently affiliated with the object.
+func (o *Object) Health() Health {
+	o.mux.Lock()
+	defer o.mux.Unlock()
+	return o.health
+}
+
+// Unhealthy returns true if the object's health is marked as Unhealthy or Failed.
+func (o *Object) Unhealthy() bool {
+	o.mux.Lock()
+	defer o.mux.Unlock()
+	return o.health == Unhealthy || o.health == Failed
+}
+
+// Error returns any error that caused the object to be unhealthy.
+func (o *Object) Error() error {
+	o.mux.Lock()
+	defer o.mux.Unlock()
+	return o.err
+}
+
+// PodStatus returns the kubernetes PodStatus object which was last supplied to the Update function.
+func (o *Object) PodStatus() v1.PodStatus {
+	o.mux.Lock()
+	defer o.mux.Unlock()
+	return o.podStatus
+}
+
+// containerState represents the current status of the single container in an object's pod. This
+// does not have a 1:1 correlation with kubernetes, because it flattens their hierarchical
+// structure.
+type containerState int
+
+const (
+	// containerStateUnknown means that the docker container state objects did not conform to
+	// any of the other containerState constants.
+	containerStateUnknown containerState = iota
+
+	// containerStateTerminated means the docker container has a non-nil terminating state
+	// object specified as a previous state.
+	containerStateTerminated
+
+	// containerStateTerminating means the docker container has a non-nil terminating state
+	// bject specified as the current state.
+	containerStateTerminating
+
+	// containerStateWaiting means the docker container is in the waiting state; however, a
+	// crash has not been detected.
+	containerStateWaiting
+
+	// containerStateCrashWaiting means the docker container is marked in a waiting state, but
+	// the reason is "CrashLoopBackOff". This means that there was a crash in the container,
+	// and kubernetes will likely try to restart it.
+	containerStateCrashWaiting
+
+	// containerStateRunning means the docker container is marked in a running state.
+	containerStateRunning
+)
+
+// phaseStateMap is a table that maps a kubernetes pod phase and the state of its container to a
+// health value. For example, a PodRunning phase and a docker container state of
+// containerStateCrashWaiting should map to Unhealthy.
+var phaseStateMap = map[v1.PodPhase]map[containerState]Health{
+	v1.PodPending: map[containerState]Health{
+		containerStateUnknown:      Unknown,
+		containerStateCrashWaiting: Unhealthy,
+		containerStateTerminated:   Unhealthy,
+		containerStateTerminating:  Unhealthy,
+	},
+
+	v1.PodRunning: map[containerState]Health{
+		containerStateUnknown:      Unhealthy,
+		containerStateRunning:      Healthy,
+		containerStateWaiting:      Unhealthy,
+		containerStateCrashWaiting: Unhealthy,
+		containerStateTerminated:   Unhealthy,
+		containerStateTerminating:  Unhealthy,
+	},
+
+	v1.PodSucceeded: map[containerState]Health{
+		containerStateUnknown:      Done,
+		containerStateRunning:      Done,
+		containerStateWaiting:      Done,
+		containerStateCrashWaiting: Failed,
+		containerStateTerminated:   Done,
+		containerStateTerminating:  Done,
+	},
+
+	v1.PodFailed: map[containerState]Health{
+		containerStateUnknown:      Failed,
+		containerStateRunning:      Failed,
+		containerStateWaiting:      Failed,
+		containerStateCrashWaiting: Failed,
+		containerStateTerminated:   Failed,
+		containerStateTerminating:  Failed,
+	},
+
+	v1.PodUnknown: map[containerState]Health{
+		containerStateUnknown:      Unknown,
+		containerStateRunning:      Unhealthy,
+		containerStateWaiting:      Unhealthy,
+		containerStateCrashWaiting: Unhealthy,
+		containerStateTerminated:   Unhealthy,
+		containerStateTerminating:  Unhealthy,
+	},
+}

--- a/testctrl/svc/orch/object_test.go
+++ b/testctrl/svc/orch/object_test.go
@@ -1,0 +1,157 @@
+package orch
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+	"github.com/grpc/grpc/testctrl/svc/types/test"
+)
+
+func TestNewObjects(t *testing.T) {
+	cs := []*types.Component{
+		test.NewComponentBuilder().Build(),
+		test.NewComponentBuilder().Build(),
+	}
+	objs := NewObjects(cs...)
+
+	if len(objs) != len(cs) {
+		t.Errorf("NewObjects did not create the correct number of objects, expected %v but got %v", len(cs), len(objs))
+	}
+
+	set := make(map[string]*types.Component)
+	for _, o := range objs {
+		set[o.Component().Name()] = o.Component()
+	}
+
+	for _, c := range cs {
+		if x := set[c.Name()]; x == nil {
+			t.Errorf("NewObjects did not create an object for component %v", c.Name())
+		}
+	}
+}
+
+func TestObjectUpdate(t *testing.T) {
+	cases := []struct {
+		phase          v1.PodPhase
+		cstatus        containerStateTestCase
+		expectedHealth Health
+	}{
+		// pod pending cases
+		{v1.PodPending, terminatedState, Unhealthy},
+		{v1.PodPending, terminatingState, Unhealthy},
+		{v1.PodPending, waitingState, Unknown},
+		{v1.PodPending, crashWaitingState, Unhealthy},
+		{v1.PodPending, runningState, Unknown},
+		{v1.PodPending, emptyState, Unknown},
+
+		// pod running cases
+		{v1.PodRunning, terminatedState, Unhealthy},
+		{v1.PodRunning, terminatingState, Unhealthy},
+		{v1.PodRunning, waitingState, Unhealthy},
+		{v1.PodRunning, crashWaitingState, Unhealthy},
+		{v1.PodRunning, runningState, Healthy},
+		{v1.PodRunning, emptyState, Unhealthy},
+
+		// pod succeeded cases
+		{v1.PodSucceeded, terminatedState, Done},
+		{v1.PodSucceeded, terminatingState, Done},
+		{v1.PodSucceeded, waitingState, Done},
+		{v1.PodSucceeded, crashWaitingState, Failed},
+		{v1.PodSucceeded, runningState, Done},
+		{v1.PodSucceeded, emptyState, Done},
+
+		// pod failed cases
+		{v1.PodFailed, terminatedState, Failed},
+		{v1.PodFailed, terminatingState, Failed},
+		{v1.PodFailed, waitingState, Failed},
+		{v1.PodFailed, crashWaitingState, Failed},
+		{v1.PodFailed, runningState, Failed},
+		{v1.PodFailed, emptyState, Failed},
+
+		// pod unknown cases
+		{v1.PodUnknown, terminatedState, Unhealthy},
+		{v1.PodUnknown, terminatingState, Unhealthy},
+		{v1.PodUnknown, waitingState, Unhealthy},
+		{v1.PodUnknown, crashWaitingState, Unhealthy},
+		{v1.PodUnknown, runningState, Unhealthy},
+		{v1.PodUnknown, emptyState, Unknown},
+	}
+
+	for _, c := range cases {
+		status := v1.PodStatus{
+			Phase: c.phase,
+			ContainerStatuses: []v1.ContainerStatus{
+				c.cstatus.status,
+			},
+		}
+
+		o := NewObjects(test.NewComponentBuilder().Build())[0]
+		o.Update(status)
+
+		if o.Health() != c.expectedHealth {
+			t.Errorf("Object Update set health '%v' but expected '%v' for pod phase '%v' and status '%v'",
+				o.Health(), c.expectedHealth, c.phase, c.cstatus.description)
+		}
+	}
+}
+
+type containerStateTestCase struct {
+	description string
+	status      v1.ContainerStatus
+}
+
+var terminatingState = containerStateTestCase{
+	description: "container terminating",
+	status: v1.ContainerStatus{
+		State: v1.ContainerState{
+			Terminated: &v1.ContainerStateTerminated{},
+		},
+	},
+}
+
+var terminatedState = containerStateTestCase{
+	description: "container terminated",
+	status: v1.ContainerStatus{
+		LastTerminationState: v1.ContainerState{
+			Terminated: &v1.ContainerStateTerminated{},
+		},
+	},
+}
+
+var waitingState = containerStateTestCase{
+	description: "container waiting",
+	status: v1.ContainerStatus{
+		State: v1.ContainerState{
+			Waiting: &v1.ContainerStateWaiting{},
+		},
+	},
+}
+
+var crashWaitingState = containerStateTestCase{
+	description: "container crash waiting",
+	status: v1.ContainerStatus{
+		State: v1.ContainerState{
+			Waiting: &v1.ContainerStateWaiting{
+				Reason: "CrashLoopBackOff",
+			},
+		},
+	},
+}
+
+var runningState = containerStateTestCase{
+	description: "container running",
+	status: v1.ContainerStatus{
+		State: v1.ContainerState{
+			Running: &v1.ContainerStateRunning{},
+		},
+	},
+}
+
+var emptyState = containerStateTestCase{
+	description: "no container state",
+	status: v1.ContainerStatus{
+		State: v1.ContainerState{},
+	},
+}

--- a/testctrl/svc/orch/test/container_statuses.go
+++ b/testctrl/svc/orch/test/container_statuses.go
@@ -1,0 +1,73 @@
+package test
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+type ContainerStateCase struct {
+	Description string
+	Status      v1.ContainerStatus
+}
+
+var ContainerStateCases = struct {
+	Terminating  ContainerStateCase
+	Terminated   ContainerStateCase
+	Waiting      ContainerStateCase
+	CrashWaiting ContainerStateCase
+	Running      ContainerStateCase
+	Empty        ContainerStateCase
+}{
+	Terminating: ContainerStateCase{
+		Description: "container terminating",
+		Status: v1.ContainerStatus{
+			State: v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{},
+			},
+		},
+	},
+
+	Terminated: ContainerStateCase{
+		Description: "container terminated",
+		Status: v1.ContainerStatus{
+			LastTerminationState: v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{},
+			},
+		},
+	},
+
+	Waiting: ContainerStateCase{
+		Description: "container waiting",
+		Status: v1.ContainerStatus{
+			State: v1.ContainerState{
+				Waiting: &v1.ContainerStateWaiting{},
+			},
+		},
+	},
+
+	CrashWaiting: ContainerStateCase{
+		Description: "container crash waiting",
+		Status: v1.ContainerStatus{
+			State: v1.ContainerState{
+				Waiting: &v1.ContainerStateWaiting{
+					Reason: "CrashLoopBackOff",
+				},
+			},
+		},
+	},
+
+	Running: ContainerStateCase{
+		Description: "container running",
+		Status: v1.ContainerStatus{
+			State: v1.ContainerState{
+				Running: &v1.ContainerStateRunning{},
+			},
+		},
+	},
+
+	Empty: ContainerStateCase{
+		Description: "no container state",
+		Status: v1.ContainerStatus{
+			State: v1.ContainerState{},
+		},
+	},
+}


### PR DESCRIPTION
The Object struct wraps a component, the status of its pod and its health information. This is designed to be an internal type that is only used by the orch package. Its name is inspired by Kubernetes' [runtime.Object](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime?tab=doc#Object) type.

The Health type is used as an enum. It is indicative of the availability and readiness of an object.