### PR TITLE
Fix nil map issue in type Component

### DIFF
--- a/testctrl/svc/types/component.go
+++ b/testctrl/svc/types/component.go
@@ -8,7 +8,8 @@ import (
 )
 
 // Component represents a dependency for a session. Benchmarks tend to have three components: a
-// driver, server and client. Each component can have many identical replicas.
+// driver, server and client. Each component can have many identical replicas. Do not create
+// Components using a literal, use the NewComponent constructor.
 type Component struct {
 	name           string
 	containerImage string
@@ -39,6 +40,7 @@ func NewComponent(containerImage string, kind ComponentKind, replicas int32) *Co
 		containerImage: containerImage,
 		kind:           kind,
 		replicas:       replicas,
+		env:		make(map[string]string),
 	}
 }
 

--- a/testctrl/svc/types/test/component_builder.go
+++ b/testctrl/svc/types/test/component_builder.go
@@ -6,16 +6,17 @@ import (
 
 type ComponentBuilder struct {
 	container string
-	kind types.ComponentKind
-	replicas int32
-	env map[string]string
+	kind      types.ComponentKind
+	replicas  int32
+	env       map[string]string
 }
 
 func NewComponentBuilder() *ComponentBuilder {
 	return &ComponentBuilder{
 		container: "example:latest",
-		kind: types.ClientComponent,
-		replicas: 1,
+		kind:      types.ClientComponent,
+		replicas:  1,
+		env:       make(map[string]string),
 	}
 }
 


### PR DESCRIPTION
Component relies on a map to contain environmental variables that should be set. This map was never properly initialized, leading to a panic when invoking the SetEnv method.

This commit properly initializes the map on the Component, adds a comment to discourage creation of Component instances without the constructor and fixes the ComponentBuilder for testing.