### PR TITLE
Add Apache-2.0 headers and fix format issues

### DIFF
--- a/testctrl/auth/auth.go
+++ b/testctrl/auth/auth.go
@@ -52,4 +52,3 @@ func ConnectWithConfig(abspath string) (*kubernetes.Clientset, error) {
 
 	return clientset, nil
 }
-

--- a/testctrl/cmd/orchtest/main.go
+++ b/testctrl/cmd/orchtest/main.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -49,4 +63,3 @@ func main() {
 
 	time.Sleep(*timeout)
 }
-

--- a/testctrl/cmd/svc/main.go
+++ b/testctrl/cmd/svc/main.go
@@ -36,7 +36,6 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
-
 func setupProdEnv() *kubernetes.Clientset {
 	clientset, err := auth.ConnectWithinCluster()
 	if err != nil {
@@ -102,4 +101,3 @@ func main() {
 		glog.Fatalf("server unexpectedly crashed: %v", err)
 	}
 }
-

--- a/testctrl/proto/build.sh
+++ b/testctrl/proto/build.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # PATHS specifies the type of output for the go protobuf plugin. See the
 # documentation at: https://github.com/golang/protobuf#parameters.

--- a/testctrl/svc/orch/controller.go
+++ b/testctrl/svc/orch/controller.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orch
 
 import (
@@ -10,7 +24,7 @@ import (
 
 // Controller manages active and idle sessions, as well as, communications with the Kubernetes API.
 type Controller struct {
-	clientset   *kubernetes.Clientset
+	clientset *kubernetes.Clientset
 }
 
 // NewController constructs a Controller instance with a Kubernetes Clientset. This allows the
@@ -40,4 +54,3 @@ func (c *Controller) Start() error {
 func (c *Controller) Stop(timeout time.Duration) error {
 	return nil
 }
-

--- a/testctrl/svc/orch/health.go
+++ b/testctrl/svc/orch/health.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orch
 
 // Health indicates the availability or readiness of an object or a set of objects.

--- a/testctrl/svc/orch/monitor.go
+++ b/testctrl/svc/orch/monitor.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orch
 
 import (

--- a/testctrl/svc/orch/monitor_test.go
+++ b/testctrl/svc/orch/monitor_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orch
 
 import (
@@ -113,7 +127,7 @@ func TestMonitorUnhealthy(t *testing.T) {
 func TestMonitorDone(t *testing.T) {
 	cases := []struct {
 		phases []v1.PodPhase
-		done bool
+		done   bool
 	}{
 		{
 			phases: []v1.PodPhase{

--- a/testctrl/svc/orch/object.go
+++ b/testctrl/svc/orch/object.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orch
 
 import (

--- a/testctrl/svc/orch/object_test.go
+++ b/testctrl/svc/orch/object_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orch
 
 import (

--- a/testctrl/svc/orch/spec_builder.go
+++ b/testctrl/svc/orch/spec_builder.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orch
 
 import (
@@ -12,11 +26,12 @@ import (
 
 const driverPort int32 = 10000
 const serverPort int32 = 10010
+
 var zero int32 = 0
 
 // SpecBuilder creates valid Kubernetes specs for components.
 type SpecBuilder struct {
-	session *types.Session
+	session   *types.Session
 	component *types.Component
 }
 
@@ -63,12 +78,12 @@ func (sb *SpecBuilder) ContainerPorts() []apiv1.ContainerPort {
 func (sb *SpecBuilder) Deployment() *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: sb.ObjectMeta(),
-		Spec: sb.DeploymentSpec(),
+		Spec:       sb.DeploymentSpec(),
 	}
 }
 
 // DeploymentSpec builds a Kubernetes deployment spec object.
-func (sb *SpecBuilder) DeploymentSpec() appsv1.DeploymentSpec{
+func (sb *SpecBuilder) DeploymentSpec() appsv1.DeploymentSpec {
 	replicas := sb.component.Replicas()
 
 	return appsv1.DeploymentSpec{
@@ -78,11 +93,11 @@ func (sb *SpecBuilder) DeploymentSpec() appsv1.DeploymentSpec{
 		},
 		Strategy: appsv1.DeploymentStrategy{
 			// disable rolling updates
-			Type: "Recreate",
+			Type:          "Recreate",
 			RollingUpdate: nil,
 		},
-		RevisionHistoryLimit: &zero,  // disable rollbacks
-		Template: sb.PodTemplateSpec(),
+		RevisionHistoryLimit: &zero, // disable rollbacks
+		Template:             sb.PodTemplateSpec(),
 	}
 }
 
@@ -90,8 +105,8 @@ func (sb *SpecBuilder) DeploymentSpec() appsv1.DeploymentSpec{
 // component. Most importantly, it includes the component's name and necessary labels.
 func (sb *SpecBuilder) ObjectMeta() metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:        sb.component.Name(),
-		Labels:      sb.Labels(),
+		Name:   sb.component.Name(),
+		Labels: sb.Labels(),
 	}
 }
 
@@ -104,8 +119,8 @@ func (sb *SpecBuilder) ObjectMeta() metav1.ObjectMeta {
 //	 4. `component-kind` set to the kind of component (e.g. "driver")
 func (sb *SpecBuilder) Labels() map[string]string {
 	return map[string]string{
-		"autogen": "1",
-		"session-name": sb.session.Name(),
+		"autogen":        "1",
+		"session-name":   sb.session.Name(),
 		"component-name": sb.component.Name(),
 		"component-kind": strings.ToLower(sb.component.Kind().String()),
 	}
@@ -120,4 +135,3 @@ func (sb *SpecBuilder) PodTemplateSpec() apiv1.PodTemplateSpec {
 		},
 	}
 }
-

--- a/testctrl/svc/orch/spec_builder_test.go
+++ b/testctrl/svc/orch/spec_builder_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orch
 
 import (
@@ -28,7 +42,7 @@ func TestSpecBuilderContainers(t *testing.T) {
 
 func TestSpecBuilderContainerPorts(t *testing.T) {
 	cases := []struct {
-		kind types.ComponentKind
+		kind  types.ComponentKind
 		ports []int32
 	}{
 		{types.DriverComponent, []int32{driverPort}},
@@ -57,7 +71,6 @@ func TestSpecBuilderContainerPorts(t *testing.T) {
 		}
 	}
 }
-
 
 func TestSpecBuilderDeploymentSpec(t *testing.T) {
 	// Check that replicas are properly set
@@ -142,4 +155,3 @@ func TestSpecBuilderObjectMeta(t *testing.T) {
 		t.Errorf("SpecBuilder ObjectMeta did not set the K8s resource name to the component name; expected '%s' but got '%s'", componentName, resourceName)
 	}
 }
-

--- a/testctrl/svc/orch/test/container_statuses.go
+++ b/testctrl/svc/orch/test/container_statuses.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // INTERNAL TESTING CODE!
 
 package test

--- a/testctrl/svc/orch/test/pod.go
+++ b/testctrl/svc/orch/test/pod.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // INTERNAL TESTING CODE!
 
 package test
@@ -17,7 +31,7 @@ type PodBuilder struct {
 
 func NewPodBuilder() *PodBuilder {
 	return &PodBuilder{
-		phase: v1.PodRunning,
+		phase:  v1.PodRunning,
 		labels: make(map[string]string),
 	}
 }
@@ -45,7 +59,7 @@ func (pb *PodBuilder) Build() *v1.Pod {
 	pod.ObjectMeta.Name = name
 	pod.ObjectMeta.Labels = pb.labels
 	pod.Status = v1.PodStatus{
-		Phase:  pb.phase,
+		Phase: pb.phase,
 		ContainerStatuses: []v1.ContainerStatus{
 			pb.containerStatus,
 		},

--- a/testctrl/svc/types/component.go
+++ b/testctrl/svc/types/component.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
 import (
@@ -40,7 +54,7 @@ func NewComponent(containerImage string, kind ComponentKind, replicas int32) *Co
 		containerImage: containerImage,
 		kind:           kind,
 		replicas:       replicas,
-		env:		make(map[string]string),
+		env:            make(map[string]string),
 	}
 }
 

--- a/testctrl/svc/types/component_test.go
+++ b/testctrl/svc/types/component_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
 import (

--- a/testctrl/svc/types/doc.go
+++ b/testctrl/svc/types/doc.go
@@ -1,2 +1,16 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package types contains data types that are shared across the different packages of testctrl.
 package types

--- a/testctrl/svc/types/event.go
+++ b/testctrl/svc/types/event.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
 import (
@@ -106,13 +120,13 @@ var eventKindStringToConstMap = map[string]EventKind{
 }
 
 var eventKindConstToStringMap = map[EventKind]string{
-	InternalErrorEvent:  "INTERNAL_ERROR",
-	QueueEvent:     "QUEUE",
-	AcceptEvent:    "ACCEPT",
-	ProvisionEvent: "PROVISION",
-	RunEvent:       "RUN",
-	DoneEvent:      "DONE",
-	ErrorEvent:     "ERROR",
+	InternalErrorEvent: "INTERNAL_ERROR",
+	QueueEvent:         "QUEUE",
+	AcceptEvent:        "ACCEPT",
+	ProvisionEvent:     "PROVISION",
+	RunEvent:           "RUN",
+	DoneEvent:          "DONE",
+	ErrorEvent:         "ERROR",
 }
 
 // EventRecorder implementations save events to a storage medium.

--- a/testctrl/svc/types/event_test.go
+++ b/testctrl/svc/types/event_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
 import (

--- a/testctrl/svc/types/resource_namer.go
+++ b/testctrl/svc/types/resource_namer.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
 // ResourceNamer is any type that can assign a string that identifies a specific resource.

--- a/testctrl/svc/types/session.go
+++ b/testctrl/svc/types/session.go
@@ -1,11 +1,25 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
 import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	pb "github.com/codeblooded/grpc-proto/genproto/grpc/testing"
+	"github.com/google/uuid"
 )
 
 // Session is a test scenario, its components and metdata.

--- a/testctrl/svc/types/session_test.go
+++ b/testctrl/svc/types/session_test.go
@@ -1,33 +1,47 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package types_test is used to avoid a circular dependency, since these tests use the builders
 // from the subpackage and the types package itself.
 package types_test
 
 import (
-  "reflect"
-  "testing"
+	"reflect"
+	"testing"
 
-  "github.com/grpc/grpc/testctrl/svc/types"
-  "github.com/grpc/grpc/testctrl/svc/types/test"
+	"github.com/grpc/grpc/testctrl/svc/types"
+	"github.com/grpc/grpc/testctrl/svc/types/test"
 )
 
 func TestSessionFilterWorkers(t *testing.T) {
-  driver := test.NewComponentBuilder().SetKind(types.DriverComponent).Build()
-  client := test.NewComponentBuilder().SetKind(types.ClientComponent).Build()
-  server := test.NewComponentBuilder().SetKind(types.ServerComponent).Build()
-  session := test.NewSessionBuilder().SetComponents(driver, client, server).Build()
+	driver := test.NewComponentBuilder().SetKind(types.DriverComponent).Build()
+	client := test.NewComponentBuilder().SetKind(types.ClientComponent).Build()
+	server := test.NewComponentBuilder().SetKind(types.ServerComponent).Build()
+	session := test.NewSessionBuilder().SetComponents(driver, client, server).Build()
 
-  cases := []struct{
-  	methodName string
-    filterFunc func() []*types.Component
-    expected []*types.Component
-  }{
-    {"ClientWorkers", session.ClientWorkers, []*types.Component{client}},
-    {"ServerWorkers", session.ServerWorkers, []*types.Component{server}},
-  }
+	cases := []struct {
+		methodName string
+		filterFunc func() []*types.Component
+		expected   []*types.Component
+	}{
+		{"ClientWorkers", session.ClientWorkers, []*types.Component{client}},
+		{"ServerWorkers", session.ServerWorkers, []*types.Component{server}},
+	}
 
-  for _, c := range cases {
-    if results := c.filterFunc(); !reflect.DeepEqual(results, c.expected) {
-      t.Errorf("Session %v included incompatible workers: expected %v but got %v", c.methodName, c.expected, results)
-    }
-  }
+	for _, c := range cases {
+		if results := c.filterFunc(); !reflect.DeepEqual(results, c.expected) {
+			t.Errorf("Session %v included incompatible workers: expected %v but got %v", c.methodName, c.expected, results)
+		}
+	}
 }

--- a/testctrl/svc/types/test/component_builder.go
+++ b/testctrl/svc/types/test/component_builder.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // INTERNAL TESTING CODE!
 
 package test

--- a/testctrl/svc/types/test/session_builder.go
+++ b/testctrl/svc/types/test/session_builder.go
@@ -1,22 +1,36 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // INTERNAL TESTING CODE!
 
 package test
 
 import (
-	"github.com/grpc/grpc/testctrl/svc/types"
 	pb "github.com/codeblooded/grpc-proto/genproto/grpc/testing"
+	"github.com/grpc/grpc/testctrl/svc/types"
 )
 
 type SessionBuilder struct {
-	driver *types.Component
-	workers []*types.Component
+	driver   *types.Component
+	workers  []*types.Component
 	scenario *pb.Scenario
 }
 
 func NewSessionBuilder() *SessionBuilder {
 	return &SessionBuilder{
-		driver: NewComponentBuilder().SetKind(types.DriverComponent).Build(),
-		workers: []*types.Component{},
+		driver:   NewComponentBuilder().SetKind(types.DriverComponent).Build(),
+		workers:  []*types.Component{},
 		scenario: nil,
 	}
 }

--- a/testctrl/svc/version.go
+++ b/testctrl/svc/version.go
@@ -1,3 +1,17 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package svc
 
 // Version contains the current version of the service. This version complies


### PR DESCRIPTION
The Apache-2.0 license includes a header that should be commented at the beginning of every file. This PR adds the header to all files and runs them through gofmt.