### PR TITLE
Add pool and reservation management types 

### DIFF
--- a/testctrl/svc/orch/reservation.go
+++ b/testctrl/svc/orch/reservation.go
@@ -41,9 +41,9 @@ type PoolAdder interface {
 	RemovePool(pool Pool)
 }
 
-// ReservationLimiter limits the number of running sessions by considering the number of machines
+// ReservationTracker limits the number of running sessions by considering the number of machines
 // that are available in a set of pools.
-type ReservationLimiter interface {
+type ReservationTracker interface {
 	// Reserve accepts a session that is going to reserve machines and decreases the number of
 	// available machines from the appropriate pools. It does not actually reserve any machine or
 	// provision any resources.

--- a/testctrl/svc/orch/reservation.go
+++ b/testctrl/svc/orch/reservation.go
@@ -1,0 +1,251 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orch
+
+import (
+	"fmt"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+// Pool describes a cluster of identical machines.
+type Pool struct {
+	// Name is an indentifier that uniquely distinguishes a pool instance.
+	Name string
+
+	// Available is the number of machines that are idle and able to be reserved.
+	Available int
+
+	// Capacity is the total number of machines in the pool.
+	Capacity int
+}
+
+// PoolAdder is a type that can add and remove pools.
+type PoolAdder interface {
+	// AddPool adds a pool.
+	AddPool(pool Pool)
+
+	// RemovePool removes the pool.
+	RemovePool(pool Pool)
+}
+
+// ReservationLimiter limits the number of running sessions by considering the number of machines
+// that are available in a set of pools.
+type ReservationLimiter interface {
+	// Reserve accepts a session that is going to reserve machines and decreases the number of
+	// available machines from the appropriate pools. It does not actually reserve any machine or
+	// provision any resources.
+	//
+	// If there are not enough machines available in the specified pools to accomodate the
+	// session, it returns a PoolAvailabilityError. If a component references a pool that was
+	// not added to the availability instance, it returns a PoolUnknownError. If the number of
+	// machines required by the session exheeds the capacity of the pools, it returns a
+	// PoolCapacityError.
+	Reserve(session *types.Session) error
+
+	// Return accepts a session that has reserved machines that are no longer needed. It
+	// increases the number of available machines to allow other sessions to provision
+	// resources. It does not actually return, tear down or delete any machine or resources.
+	//
+	// This method makes an assumption that Reserve has been called on the session, performing
+	// no checks that the available machines in each pool do not exheed their capacities.
+	//
+	// If a component references a pool that was not added to the availability instance, it
+	// returns a PoolUnknownError.
+	Return(session *types.Session) error
+}
+
+// ReservationManager contains a set of pools and manages the availability of their machines. It is
+// designed to be used to limit the number of running sessions. It is not thread-safe.
+//
+// Instances should be created using the NewReservationManager constructor, not a literal.
+type ReservationManager struct {
+	// pools maps the name of a pool to an instance of the Pool type for quick lookups.
+	pools map[string]Pool
+}
+
+// NewReservationManager creates a new instance.
+func NewReservationManager() *ReservationManager {
+	return &ReservationManager{
+		pools: make(map[string]Pool),
+	}
+}
+
+// AddPool adds a pool to the list of pools to consider when checking for availability.
+func (rm *ReservationManager) AddPool(pool Pool) {
+	rm.pools[pool.Name] = pool
+}
+
+// AddPool removes a pool from the list of pools to consider when checking for availability. If the
+// pool was never added, it returns a PoolUnknownError.
+func (rm *ReservationManager) RemovePool(pool Pool) error {
+	name := pool.Name
+	if _, ok := rm.pools[name]; !ok {
+		return PoolUnknownError{name}
+	}
+
+	delete(rm.pools, name)
+	return nil
+}
+
+// Reserve accepts a session that is going to reserve machines and decreases the number of available
+// machines from the appropriate pools. It does not actually reserve any machine or provision any
+// resources.
+//
+// If there are not enough machines available in the specified pools to accomodate the session, it
+// returns a PoolAvailabilityError. If a component references a pool that was not added to the
+// availability instance, it returns a PoolUnknownError. If the number of machines required by the
+// session exheeds the capacity of the pools, it returns a PoolCapacityError.
+func (rm *ReservationManager) Reserve(session *types.Session) error {
+	components := sessionComponents(session)
+
+	machineCounts, err := rm.machineCounts(components)
+	if err != nil {
+		return err
+	}
+
+	fits, err := rm.fits(machineCounts)
+	if err != nil {
+		return err
+	}
+	if !fits {
+		return PoolAvailabilityError{}
+	}
+
+	for name, count := range machineCounts {
+		pool := rm.pools[name]
+		pool.Available -= count
+		rm.pools[name] = pool
+	}
+	return nil
+}
+
+// Return accepts a session that has reserved machines that are no longer needed. It increases the
+// number of available machines to allow other sessions to provision resources. It does not actually
+// return, tear down or delete any machine or resources.
+//
+// This method makes an assumption that Reserve has been called on the session, performing no checks
+// that the available machines in each pool do not exheed their capacities.
+//
+// If a component references a pool that was not added to the availability instance, it returns a
+// PoolUnknownError.
+func (rm *ReservationManager) Return(session *types.Session) error {
+	components := sessionComponents(session)
+
+	machineCounts, err := rm.machineCounts(components)
+	if err != nil {
+		return err
+	}
+
+	for name, count := range machineCounts {
+		pool := rm.pools[name]
+		pool.Available += count
+		rm.pools[name] = pool
+	}
+	return nil
+}
+
+// machineCounts returns a map with the name of each pool as the key and the number of machines
+// required from the pool as the value. If a component references a pool that was not added to the
+// availability instance, it returns a PoolUnknownError.
+func (rm *ReservationManager) machineCounts(components []*types.Component) (map[string]int, error) {
+	machines := make(map[string]int)
+
+	for poolName, _ := range rm.pools {
+		machines[poolName] = 0
+	}
+
+	for _, component := range components {
+		if c, ok := machines[component.PoolName]; ok {
+			machines[component.PoolName] = c + 1
+		} else {
+			return nil, PoolUnknownError{component.PoolName}
+		}
+	}
+
+	return machines, nil
+}
+
+// fits accepts a map with pool names as keys and number of required machines within the pool as
+// values. It returns true if there are enough available resources to schedule. If the number of
+// machines required exheeds the capacity of the pools, it returns a PoolCapacityError.
+func (rm *ReservationManager) fits(machineCounts map[string]int) (bool, error) {
+	for poolName, c := range machineCounts {
+		pool := rm.pools[poolName]
+
+		if c > pool.Capacity {
+			return false, PoolCapacityError{poolName, c, pool.Capacity}
+		}
+
+		if c > pool.Available {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// PoolAvailabilityError indicates Reserve was called with a session that required a number of
+// machines that were not currently available. These machines may become available at another time.
+type PoolAvailabilityError struct{}
+
+// Error returns a string representation of the available error message.
+func (pae PoolAvailabilityError) Error() string {
+	return fmt.Sprintf("not enough machines are available to accomodate the reservation")
+}
+
+// PoolCapacityError indicates that a session requires a number of machines which is greater than
+// the number of machines in the pool. The session can never be scheduled.
+type PoolCapacityError struct {
+	// Name is the string identifier for the pool.
+	Name string
+
+	// Requested is the number of machines that the session requires.
+	Requested int
+
+	// Capacity is the maximum number of machines that the pool can accomodate.
+	Capacity int
+}
+
+// Error returns a string representation of the capacity error message.
+func (pce PoolCapacityError) Error() string {
+	return fmt.Sprintf("pool %v has only %v machines, but the session required %v machines",
+		pce.Name, pce.Requested, pce.Capacity)
+}
+
+// PoolUnknownError indicates that a session component required a pool that was not added on the
+// availability instance.
+type PoolUnknownError struct {
+	// Name is the string identifier for a un-added pool.
+	Name string
+}
+
+// Error returns a string representation of the unknown error message.
+func (pue PoolUnknownError) Error() string {
+	return fmt.Sprintf("pool '%v' was referenced, but not added to the availability instance",
+		pue.Name)
+}
+
+// sessionComponents collects and returns a slice with all of a session's components.
+func sessionComponents(session *types.Session) []*types.Component {
+	components := []*types.Component{}
+	if session.Driver != nil {
+		components = append(components, session.Driver)
+	}
+	for _, w := range session.Workers {
+		components = append(components, w)
+	}
+	return components
+}

--- a/testctrl/svc/orch/reservation.go
+++ b/testctrl/svc/orch/reservation.go
@@ -55,16 +55,16 @@ type ReservationTracker interface {
 	// PoolCapacityError.
 	Reserve(session *types.Session) error
 
-	// Return accepts a session that has reserved machines that are no longer needed. It
+	// Unreserve accepts a session that has reserved machines that are no longer needed. It
 	// increases the number of available machines to allow other sessions to provision
 	// resources. It does not actually return, tear down or delete any machine or resources.
 	//
 	// This method makes an assumption that Reserve has been called on the session, performing
 	// no checks that the available machines in each pool do not exceeds their capacities.
 	//
-	// If a component references a pool that was not added to the availability instance, it
+	// If a component references a pool that was Unreserve added to the availability instance, it
 	// returns a PoolUnknownError.
-	Return(session *types.Session) error
+	Unreserve(session *types.Session) error
 }
 
 // ReservationManager contains a set of pools and manages the availability of their machines. It is
@@ -132,16 +132,16 @@ func (rm *ReservationManager) Reserve(session *types.Session) error {
 	return nil
 }
 
-// Return accepts a session that has reserved machines that are no longer needed. It increases the
-// number of available machines to allow other sessions to provision resources. It does not actually
-// return, tear down or delete any machine or resources.
+// Unreserve accepts a session that has reserved machines that are no longer needed. It increases
+// the number of available machines to allow other sessions to provision resources. It does not
+// actually return, tear down or delete any machine or resources.
 //
 // This method makes an assumption that Reserve has been called on the session, performing no checks
 // that the available machines in each pool do not exceeds their capacities.
 //
 // If a component references a pool that was not added to the availability instance, it returns a
 // PoolUnknownError.
-func (rm *ReservationManager) Return(session *types.Session) error {
+func (rm *ReservationManager) Unreserve(session *types.Session) error {
 	components := sessionComponents(session)
 
 	machineCounts, err := rm.machineCounts(components)

--- a/testctrl/svc/orch/reservation.go
+++ b/testctrl/svc/orch/reservation.go
@@ -51,7 +51,7 @@ type ReservationLimiter interface {
 	// If there are not enough machines available in the specified pools to accomodate the
 	// session, it returns a PoolAvailabilityError. If a component references a pool that was
 	// not added to the availability instance, it returns a PoolUnknownError. If the number of
-	// machines required by the session exheeds the capacity of the pools, it returns a
+	// machines required by the session exceeds the capacity of the pools, it returns a
 	// PoolCapacityError.
 	Reserve(session *types.Session) error
 
@@ -60,7 +60,7 @@ type ReservationLimiter interface {
 	// resources. It does not actually return, tear down or delete any machine or resources.
 	//
 	// This method makes an assumption that Reserve has been called on the session, performing
-	// no checks that the available machines in each pool do not exheed their capacities.
+	// no checks that the available machines in each pool do not exceeds their capacities.
 	//
 	// If a component references a pool that was not added to the availability instance, it
 	// returns a PoolUnknownError.
@@ -107,7 +107,7 @@ func (rm *ReservationManager) RemovePool(pool Pool) error {
 // If there are not enough machines available in the specified pools to accomodate the session, it
 // returns a PoolAvailabilityError. If a component references a pool that was not added to the
 // availability instance, it returns a PoolUnknownError. If the number of machines required by the
-// session exheeds the capacity of the pools, it returns a PoolCapacityError.
+// session exceeds the capacity of the pools, it returns a PoolCapacityError.
 func (rm *ReservationManager) Reserve(session *types.Session) error {
 	components := sessionComponents(session)
 
@@ -137,7 +137,7 @@ func (rm *ReservationManager) Reserve(session *types.Session) error {
 // return, tear down or delete any machine or resources.
 //
 // This method makes an assumption that Reserve has been called on the session, performing no checks
-// that the available machines in each pool do not exheed their capacities.
+// that the available machines in each pool do not exceeds their capacities.
 //
 // If a component references a pool that was not added to the availability instance, it returns a
 // PoolUnknownError.
@@ -180,7 +180,7 @@ func (rm *ReservationManager) machineCounts(components []*types.Component) (map[
 
 // fits accepts a map with pool names as keys and number of required machines within the pool as
 // values. It returns true if there are enough available resources to schedule. If the number of
-// machines required exheeds the capacity of the pools, it returns a PoolCapacityError.
+// machines required exceeds the capacity of the pools, it returns a PoolCapacityError.
 func (rm *ReservationManager) fits(machineCounts map[string]int) (bool, error) {
 	for poolName, c := range machineCounts {
 		pool := rm.pools[poolName]

--- a/testctrl/svc/orch/reservation_test.go
+++ b/testctrl/svc/orch/reservation_test.go
@@ -1,0 +1,245 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orch
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+func TestAvailabilityAddPool(t *testing.T) {
+	rm := NewReservationManager()
+	poolName := "TestPool"
+	pool := Pool{Name: poolName}
+
+	rm.AddPool(pool)
+	found, exists := rm.pools[poolName]
+	if !exists {
+		t.Fatalf("did not add pool to internal map")
+	}
+	if !reflect.DeepEqual(pool, found) {
+		t.Fatalf("unexpectedly mutated pool during addition")
+	}
+}
+
+func TestAvailabilityRemovePool(t *testing.T) {
+	rm := NewReservationManager()
+	pool := Pool{
+		Name:      "TestPool",
+		Available: 10,
+		Capacity:  100,
+	}
+
+	// test remove with original object
+	rm.pools[pool.Name] = pool
+	rm.RemovePool(pool)
+	if _, exists := rm.pools[pool.Name]; exists {
+		t.Errorf("did not remove original pool from internal map")
+	}
+
+	// test remove with identically-named object
+	rm.pools[pool.Name] = pool
+	rm.RemovePool(Pool{Name: pool.Name})
+	if _, exists := rm.pools[pool.Name]; exists {
+		t.Errorf("did not remove pool with identical name from internal map")
+	}
+
+	// test error raised if pool does not exist
+	fakePool := Pool{Name: "WaymoPool"}
+	if err := rm.RemovePool(fakePool); err == nil {
+		t.Errorf("did not error for non-existent pool")
+	}
+}
+
+func TestAvailabilityReserve(t *testing.T) {
+	cases := []struct {
+		description      string
+		workerCount      int
+		workerPoolBefore Pool
+		workerPoolAfter  Pool
+		err              error
+	}{
+		{
+			description:      "capacity exheeded",
+			workerCount:      5,
+			workerPoolBefore: Pool{Available: 4, Capacity: 4},
+			workerPoolAfter:  Pool{Available: 4, Capacity: 4},
+			err:              PoolCapacityError{},
+		},
+		{
+			description:      "not available",
+			workerCount:      7,
+			workerPoolBefore: Pool{Available: 5, Capacity: 7},
+			workerPoolAfter:  Pool{Available: 5, Capacity: 7},
+			err:              PoolAvailabilityError{},
+		},
+		{
+			description:      "exact availability match",
+			workerCount:      3,
+			workerPoolBefore: Pool{Available: 3, Capacity: 3},
+			workerPoolAfter:  Pool{Available: 0, Capacity: 3},
+			err:              nil,
+		},
+		{
+			description:      "availability match greater",
+			workerCount:      3,
+			workerPoolBefore: Pool{Available: 8, Capacity: 9},
+			workerPoolAfter:  Pool{Available: 5, Capacity: 9},
+			err:              nil,
+		},
+	}
+
+	for _, c := range cases {
+		rm := NewReservationManager()
+
+		driverPool := Pool{
+			Name:      "DriverPool",
+			Available: 1,
+			Capacity:  1,
+		}
+		rm.AddPool(driverPool)
+
+		workerPool := c.workerPoolBefore
+		workerPool.Name = "WorkerPool"
+		rm.AddPool(workerPool)
+
+		driver := types.NewComponent(testContainerImage, types.DriverComponent)
+		driver.PoolName = driverPool.Name
+
+		var workers []*types.Component
+		for i := 0; i < c.workerCount; i++ {
+			component := types.NewComponent(testContainerImage, types.ClientComponent)
+			component.PoolName = workerPool.Name
+			workers = append(workers, component)
+		}
+
+		session := types.NewSession(driver, workers, nil)
+
+		err := rm.Reserve(session)
+		expectedErrType := reflect.TypeOf(c.err)
+		actualErrType := reflect.TypeOf(err)
+		if c.err != nil {
+			// check for the proper error
+			if expectedErrType != actualErrType {
+				t.Errorf("expected %v error for case %v, but got %v: %v",
+					expectedErrType.Name(), c.description, actualErrType.Name(), err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error returned: %v", err)
+			}
+		}
+
+		got := rm.pools[workerPool.Name]
+		if got.Available != c.workerPoolAfter.Available {
+			t.Errorf("expected %v machines remaining after reserve, but got %v",
+				c.workerPoolAfter.Available, got.Available)
+		}
+		if got.Capacity != c.workerPoolAfter.Capacity {
+			t.Errorf("expected %v machine capacity after reserve, but got %v",
+				c.workerPoolAfter.Capacity, got.Capacity)
+		}
+	}
+
+	// check error returned for unknown pool
+	rm := NewReservationManager()
+	rm.AddPool(Pool{Name: "KnownPool"})
+
+	driver := types.NewComponent(testContainerImage, types.DriverComponent)
+	driver.PoolName = "UnknownPool"
+
+	session := types.NewSession(driver, nil, nil)
+
+	err := rm.Reserve(session)
+	errType := reflect.TypeOf(err)
+	if errType == nil || errType != reflect.TypeOf(PoolUnknownError{}) {
+		t.Errorf("expected pool unknown error for un-added pool, but got %v", errType.Name())
+	}
+}
+
+func TestAvailabilityReturn(t *testing.T) {
+	cases := []struct {
+		description      string
+		workerCount      int
+		workerPoolBefore Pool
+		workerPoolAfter  Pool
+	}{
+		{
+			description:      "default",
+			workerCount:      3,
+			workerPoolBefore: Pool{Available: 4, Capacity: 7},
+			workerPoolAfter:  Pool{Available: 7, Capacity: 7},
+		},
+	}
+
+	for _, c := range cases {
+		rm := NewReservationManager()
+
+		driverPool := Pool{
+			Name:      "DriverPool",
+			Available: 1,
+			Capacity:  1,
+		}
+		rm.AddPool(driverPool)
+
+		workerPool := c.workerPoolBefore
+		workerPool.Name = "WorkerPool"
+		rm.AddPool(workerPool)
+
+		driver := types.NewComponent(testContainerImage, types.DriverComponent)
+		driver.PoolName = driverPool.Name
+
+		var workers []*types.Component
+		for i := 0; i < c.workerCount; i++ {
+			component := types.NewComponent(testContainerImage, types.ClientComponent)
+			component.PoolName = workerPool.Name
+			workers = append(workers, component)
+		}
+
+		session := types.NewSession(driver, workers, nil)
+
+		err := rm.Return(session)
+		if err != nil {
+			t.Errorf("unexpected error returned: %v", err)
+		}
+
+		got := rm.pools[workerPool.Name]
+		if got.Available != c.workerPoolAfter.Available {
+			t.Errorf("expected %v machines remaining after return, but got %v",
+				c.workerPoolAfter.Available, got.Available)
+		}
+		if got.Capacity != c.workerPoolAfter.Capacity {
+			t.Errorf("expected %v machine capacity after return, but got %v",
+				c.workerPoolAfter.Capacity, got.Capacity)
+		}
+	}
+
+	// check error returned for unknown pool
+	rm := NewReservationManager()
+	rm.AddPool(Pool{Name: "KnownPool"})
+
+	driver := types.NewComponent(testContainerImage, types.DriverComponent)
+	driver.PoolName = "UnknownPool"
+
+	session := types.NewSession(driver, nil, nil)
+
+	err := rm.Return(session)
+	errType := reflect.TypeOf(err)
+	if errType == nil || errType != reflect.TypeOf(PoolUnknownError{}) {
+		t.Errorf("expected pool unknown error for un-added pool, but got %v", errType.Name())
+	}
+}

--- a/testctrl/svc/orch/reservation_test.go
+++ b/testctrl/svc/orch/reservation_test.go
@@ -171,7 +171,7 @@ func TestAvailabilityReserve(t *testing.T) {
 	}
 }
 
-func TestAvailabilityReturn(t *testing.T) {
+func TestAvailabilityUnreserve(t *testing.T) {
 	cases := []struct {
 		description      string
 		workerCount      int
@@ -212,7 +212,7 @@ func TestAvailabilityReturn(t *testing.T) {
 
 		session := types.NewSession(driver, workers, nil)
 
-		err := rm.Return(session)
+		err := rm.Unreserve(session)
 		if err != nil {
 			t.Errorf("unexpected error returned: %v", err)
 		}
@@ -237,7 +237,7 @@ func TestAvailabilityReturn(t *testing.T) {
 
 	session := types.NewSession(driver, nil, nil)
 
-	err := rm.Return(session)
+	err := rm.Unreserve(session)
 	errType := reflect.TypeOf(err)
 	if errType == nil || errType != reflect.TypeOf(PoolUnknownError{}) {
 		t.Errorf("expected pool unknown error for un-added pool, but got %v", errType.Name())

--- a/testctrl/svc/orch/reservation_test.go
+++ b/testctrl/svc/orch/reservation_test.go
@@ -74,7 +74,7 @@ func TestAvailabilityReserve(t *testing.T) {
 		err              error
 	}{
 		{
-			description:      "capacity exheeded",
+			description:      "capacity exceeded",
 			workerCount:      5,
 			workerPoolBefore: Pool{Available: 4, Capacity: 4},
 			workerPoolAfter:  Pool{Available: 4, Capacity: 4},

--- a/testctrl/svc/orch/testing.go
+++ b/testctrl/svc/orch/testing.go
@@ -1,0 +1,4 @@
+package orch
+
+// testContainerImage is a default container image supplied during component construction in tests.
+const testContainerImage = "example:latest"


### PR DESCRIPTION
This change adds a set of structs and interfaces. These can be used to limit the number of running sessions in consideration of the number of machines available.