### PR TITLE
Add preliminary thread-safe availability queue

### DIFF
--- a/testctrl/svc/orch/queue.go
+++ b/testctrl/svc/orch/queue.go
@@ -1,0 +1,86 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orch
+
+import (
+	"sync"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+// Queue provides a thread-safe FIFO structure that uses a ReservationTracker to only dequeue
+// sessions when there are enough available machines.
+type Queue struct {
+	items   []*queueItem
+	tracker ReservationTracker
+	mux     sync.Mutex
+}
+
+// NewQueue constructs a queue, given a ReservationTracker.
+func NewQueue(tracker ReservationTracker) *Queue {
+	return &Queue{
+		tracker: tracker,
+	}
+}
+
+// Enqueue adds a session to the queue.
+func (q *Queue) Enqueue(session *types.Session) error {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	q.items = append(q.items, &queueItem{session})
+	return nil
+}
+
+// Dequeue tries to remove a session from the queue that can run with the current availability. If
+// no session can run with the current availability or there are none queued, it returns nil.
+//
+// If a session is returned, it is the responsibility of the caller to invoke the Done method when
+// the session no longer requires its machines.
+func (q *Queue) Dequeue() *types.Session {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+
+	for i, item := range q.items {
+		session := item.session
+		if err := q.tracker.Reserve(session); err == nil {
+			// delete item from queue, preserving order of others
+			q.items = append(q.items[:i], q.items[i+1:]...)
+			return session
+		}
+	}
+
+	return nil
+}
+
+// Done marks the termination of a session, allowing the machines to be used by another session.
+func (q *Queue) Done(session *types.Session) {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	q.tracker.Unreserve(session)
+}
+
+// Count returns the number of sessions in the queue.
+func (q *Queue) Count() int {
+	q.mux.Lock()
+	defer q.mux.Unlock()
+	return len(q.items)
+}
+
+// queueItem is an internal type which wraps a queued session, designed to allow additional metadata
+// and statistics to be coupled with it.
+type queueItem struct {
+	// session is the waiting session.
+	session *types.Session
+}

--- a/testctrl/svc/orch/queue_test.go
+++ b/testctrl/svc/orch/queue_test.go
@@ -1,0 +1,198 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orch
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+func TestQueueCount(t *testing.T) {
+	n := 3 // number of sessions
+	queue := NewQueue(limitlessTracker{})
+	sessions := makeSessions(t, n)
+	for _, session := range sessions {
+		queue.Enqueue(session)
+	}
+
+	if count := queue.Count(); count != n {
+		t.Errorf("count did not return accurate number of items, expected %v but got %v", n, count)
+	}
+}
+
+func TestQueueEnqueue(t *testing.T) {
+	n := 3 // number of sessions
+	queue := NewQueue(limitlessTracker{})
+
+	expectedSessions := makeSessions(t, n)
+	for _, session := range expectedSessions {
+		if err := queue.Enqueue(session); err != nil {
+			t.Fatalf("encountered unexpected error during session creation: %v", err)
+		}
+	}
+
+	for i, expected := range expectedSessions {
+		actual := queue.items[i].session
+
+		if !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("items were missed or added in an incorrect order: %v != %v", actual, expected)
+		}
+	}
+}
+
+func TestQueueDequeue(t *testing.T) {
+	n := 3 // number of sessions
+	var queue *Queue
+	var sessions []*types.Session
+
+	// test FIFO-order preserved when it can accomodate all sessions
+	queue = NewQueue(limitlessTracker{})
+	sessions = makeSessions(t, n)
+	for _, session := range sessions {
+		queue.items = append(queue.items, &queueItem{session})
+	}
+
+	for i, expected := range sessions {
+		got := queue.Dequeue()
+		if !reflect.DeepEqual(got, expected) {
+			t.Errorf("dequeue (iteration %v of %v) was out of order, got %v but expected %v", i+1, n, got, expected)
+		}
+	}
+
+	// test using ReservationManager
+	poolName := "DequeuePool"
+	rm := NewReservationManager()
+	rm.AddPool(Pool{
+		Name:      poolName,
+		Available: 3,
+		Capacity:  5,
+	})
+
+	queue = NewQueue(rm)
+
+	sessions = makeSessions(t, 3)
+
+	sessions[0].Workers = makeWorkers(t, 5, &poolName)
+	queue.Enqueue(sessions[0])
+
+	sessions[1].Workers = makeWorkers(t, 3, &poolName)
+	queue.Enqueue(sessions[1])
+
+	sessions[2].Workers = makeWorkers(t, 1, &poolName)
+	queue.Enqueue(sessions[2])
+
+	got := queue.Dequeue()
+	if !reflect.DeepEqual(got, sessions[1]) {
+		t.Errorf("dequeue out of order (FIFO then availability), expected %v but got %v", sessions[1], got)
+	}
+
+	// test returns nil if queue is empty
+	queue = NewQueue(limitlessTracker{})
+	if queue.Dequeue() != nil {
+		t.Errorf("dequeue returned an object other than <nil> with nothing enqueued")
+	}
+}
+
+func TestQueueDone(t *testing.T) {
+	// check that other workers that need the machines can be dequeued after a done call
+	rm := NewReservationManager()
+	pool := Pool{
+		Name:      "DonePool",
+		Available: 7,
+		Capacity:  7,
+	}
+	rm.AddPool(pool)
+
+	queue := NewQueue(rm)
+
+	fiveWorkers := makeWorkers(t, 5, &pool.Name)
+	session1 := types.NewSession(nil, fiveWorkers, nil)
+	if err := queue.Enqueue(session1); err != nil {
+		t.Fatalf("could not enqueue session1 as part of test setup")
+	}
+
+	fourWorkers := makeWorkers(t, 4, &pool.Name)
+	session2 := types.NewSession(nil, fourWorkers, nil)
+	if err := queue.Enqueue(session2); err != nil {
+		t.Fatalf("could not enqueue session2 as part of test setup")
+	}
+
+	twoWorkers := makeWorkers(t, 2, &pool.Name)
+	session3 := types.NewSession(nil, twoWorkers, nil)
+	if err := queue.Enqueue(session3); err != nil {
+		t.Fatalf("could not enqueue session3 as part of test setup")
+	}
+
+	session := queue.Dequeue()
+	if session != session1 {
+		t.Fatalf("session1 was not dequeued first, test setup failed: %v != %v", session, session1)
+	}
+
+	session = queue.Dequeue()
+	if session != session3 {
+		t.Fatalf("session3 was not dequeued second, test setup failed: %v != %v", session, session3)
+	}
+
+	queue.Done(session1)
+	queue.Done(session3)
+
+	if session := queue.Dequeue(); session != session2 {
+		t.Fatalf("session2 not dequeued, indicating Done is likely not increasing available machines")
+	}
+}
+
+type limitlessTracker struct{}
+
+func (lt limitlessTracker) Reserve(session *types.Session) error {
+	return nil
+}
+
+func (lt limitlessTracker) Unreserve(session *types.Session) error {
+	return nil
+}
+
+func makeSessions(t *testing.T, n int) []*types.Session {
+	t.Helper()
+	var sessions []*types.Session
+	for i := 0; i < n; i++ {
+		sessions = append(sessions, types.NewSession(nil, nil, nil))
+	}
+	return sessions
+}
+
+func makeWorkers(t *testing.T, n int, pool *string) []*types.Component {
+	t.Helper()
+	var components []*types.Component
+
+	if n < 1 {
+		return components
+	}
+
+	components = append(components, types.NewComponent(testContainerImage, types.ServerComponent))
+
+	for i := n - 1; i > 0; i-- {
+		components = append(components, types.NewComponent(testContainerImage, types.ClientComponent))
+	}
+
+	if pool != nil {
+		for _, c := range components {
+			c.PoolName = *pool
+		}
+	}
+
+	return components
+}

--- a/testctrl/svc/orch/reservation.go
+++ b/testctrl/svc/orch/reservation.go
@@ -41,9 +41,9 @@ type PoolAdder interface {
 	RemovePool(pool Pool)
 }
 
-// ReservationLimiter limits the number of running sessions by considering the number of machines
+// ReservationTracker limits the number of running sessions by considering the number of machines
 // that are available in a set of pools.
-type ReservationLimiter interface {
+type ReservationTracker interface {
 	// Reserve accepts a session that is going to reserve machines and decreases the number of
 	// available machines from the appropriate pools. It does not actually reserve any machine or
 	// provision any resources.

--- a/testctrl/svc/orch/reservation.go
+++ b/testctrl/svc/orch/reservation.go
@@ -1,0 +1,251 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orch
+
+import (
+	"fmt"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+// Pool describes a cluster of identical machines.
+type Pool struct {
+	// Name is an indentifier that uniquely distinguishes a pool instance.
+	Name string
+
+	// Available is the number of machines that are idle and able to be reserved.
+	Available int
+
+	// Capacity is the total number of machines in the pool.
+	Capacity int
+}
+
+// PoolAdder is a type that can add and remove pools.
+type PoolAdder interface {
+	// AddPool adds a pool.
+	AddPool(pool Pool)
+
+	// RemovePool removes the pool.
+	RemovePool(pool Pool)
+}
+
+// ReservationLimiter limits the number of running sessions by considering the number of machines
+// that are available in a set of pools.
+type ReservationLimiter interface {
+	// Reserve accepts a session that is going to reserve machines and decreases the number of
+	// available machines from the appropriate pools. It does not actually reserve any machine or
+	// provision any resources.
+	//
+	// If there are not enough machines available in the specified pools to accomodate the
+	// session, it returns a PoolAvailabilityError. If a component references a pool that was
+	// not added to the availability instance, it returns a PoolUnknownError. If the number of
+	// machines required by the session exheeds the capacity of the pools, it returns a
+	// PoolCapacityError.
+	Reserve(session *types.Session) error
+
+	// Return accepts a session that has reserved machines that are no longer needed. It
+	// increases the number of available machines to allow other sessions to provision
+	// resources. It does not actually return, tear down or delete any machine or resources.
+	//
+	// This method makes an assumption that Reserve has been called on the session, performing
+	// no checks that the available machines in each pool do not exheed their capacities.
+	//
+	// If a component references a pool that was not added to the availability instance, it
+	// returns a PoolUnknownError.
+	Return(session *types.Session) error
+}
+
+// ReservationManager contains a set of pools and manages the availability of their machines. It is
+// designed to be used to limit the number of running sessions. It is not thread-safe.
+//
+// Instances should be created using the NewReservationManager constructor, not a literal.
+type ReservationManager struct {
+	// pools maps the name of a pool to an instance of the Pool type for quick lookups.
+	pools map[string]Pool
+}
+
+// NewReservationManager creates a new instance.
+func NewReservationManager() *ReservationManager {
+	return &ReservationManager{
+		pools: make(map[string]Pool),
+	}
+}
+
+// AddPool adds a pool to the list of pools to consider when checking for availability.
+func (rm *ReservationManager) AddPool(pool Pool) {
+	rm.pools[pool.Name] = pool
+}
+
+// AddPool removes a pool from the list of pools to consider when checking for availability. If the
+// pool was never added, it returns a PoolUnknownError.
+func (rm *ReservationManager) RemovePool(pool Pool) error {
+	name := pool.Name
+	if _, ok := rm.pools[name]; !ok {
+		return PoolUnknownError{name}
+	}
+
+	delete(rm.pools, name)
+	return nil
+}
+
+// Reserve accepts a session that is going to reserve machines and decreases the number of available
+// machines from the appropriate pools. It does not actually reserve any machine or provision any
+// resources.
+//
+// If there are not enough machines available in the specified pools to accomodate the session, it
+// returns a PoolAvailabilityError. If a component references a pool that was not added to the
+// availability instance, it returns a PoolUnknownError. If the number of machines required by the
+// session exheeds the capacity of the pools, it returns a PoolCapacityError.
+func (rm *ReservationManager) Reserve(session *types.Session) error {
+	components := sessionComponents(session)
+
+	machineCounts, err := rm.machineCounts(components)
+	if err != nil {
+		return err
+	}
+
+	fits, err := rm.fits(machineCounts)
+	if err != nil {
+		return err
+	}
+	if !fits {
+		return PoolAvailabilityError{}
+	}
+
+	for name, count := range machineCounts {
+		pool := rm.pools[name]
+		pool.Available -= count
+		rm.pools[name] = pool
+	}
+	return nil
+}
+
+// Return accepts a session that has reserved machines that are no longer needed. It increases the
+// number of available machines to allow other sessions to provision resources. It does not actually
+// return, tear down or delete any machine or resources.
+//
+// This method makes an assumption that Reserve has been called on the session, performing no checks
+// that the available machines in each pool do not exheed their capacities.
+//
+// If a component references a pool that was not added to the availability instance, it returns a
+// PoolUnknownError.
+func (rm *ReservationManager) Return(session *types.Session) error {
+	components := sessionComponents(session)
+
+	machineCounts, err := rm.machineCounts(components)
+	if err != nil {
+		return err
+	}
+
+	for name, count := range machineCounts {
+		pool := rm.pools[name]
+		pool.Available += count
+		rm.pools[name] = pool
+	}
+	return nil
+}
+
+// machineCounts returns a map with the name of each pool as the key and the number of machines
+// required from the pool as the value. If a component references a pool that was not added to the
+// availability instance, it returns a PoolUnknownError.
+func (rm *ReservationManager) machineCounts(components []*types.Component) (map[string]int, error) {
+	machines := make(map[string]int)
+
+	for poolName, _ := range rm.pools {
+		machines[poolName] = 0
+	}
+
+	for _, component := range components {
+		if c, ok := machines[component.PoolName]; ok {
+			machines[component.PoolName] = c + 1
+		} else {
+			return nil, PoolUnknownError{component.PoolName}
+		}
+	}
+
+	return machines, nil
+}
+
+// fits accepts a map with pool names as keys and number of required machines within the pool as
+// values. It returns true if there are enough available resources to schedule. If the number of
+// machines required exheeds the capacity of the pools, it returns a PoolCapacityError.
+func (rm *ReservationManager) fits(machineCounts map[string]int) (bool, error) {
+	for poolName, c := range machineCounts {
+		pool := rm.pools[poolName]
+
+		if c > pool.Capacity {
+			return false, PoolCapacityError{poolName, c, pool.Capacity}
+		}
+
+		if c > pool.Available {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// PoolAvailabilityError indicates Reserve was called with a session that required a number of
+// machines that were not currently available. These machines may become available at another time.
+type PoolAvailabilityError struct{}
+
+// Error returns a string representation of the available error message.
+func (pae PoolAvailabilityError) Error() string {
+	return fmt.Sprintf("not enough machines are available to accomodate the reservation")
+}
+
+// PoolCapacityError indicates that a session requires a number of machines which is greater than
+// the number of machines in the pool. The session can never be scheduled.
+type PoolCapacityError struct {
+	// Name is the string identifier for the pool.
+	Name string
+
+	// Requested is the number of machines that the session requires.
+	Requested int
+
+	// Capacity is the maximum number of machines that the pool can accomodate.
+	Capacity int
+}
+
+// Error returns a string representation of the capacity error message.
+func (pce PoolCapacityError) Error() string {
+	return fmt.Sprintf("pool %v has only %v machines, but the session required %v machines",
+		pce.Name, pce.Requested, pce.Capacity)
+}
+
+// PoolUnknownError indicates that a session component required a pool that was not added on the
+// availability instance.
+type PoolUnknownError struct {
+	// Name is the string identifier for a un-added pool.
+	Name string
+}
+
+// Error returns a string representation of the unknown error message.
+func (pue PoolUnknownError) Error() string {
+	return fmt.Sprintf("pool '%v' was referenced, but not added to the availability instance",
+		pue.Name)
+}
+
+// sessionComponents collects and returns a slice with all of a session's components.
+func sessionComponents(session *types.Session) []*types.Component {
+	components := []*types.Component{}
+	if session.Driver != nil {
+		components = append(components, session.Driver)
+	}
+	for _, w := range session.Workers {
+		components = append(components, w)
+	}
+	return components
+}

--- a/testctrl/svc/orch/reservation.go
+++ b/testctrl/svc/orch/reservation.go
@@ -55,16 +55,16 @@ type ReservationTracker interface {
 	// PoolCapacityError.
 	Reserve(session *types.Session) error
 
-	// Return accepts a session that has reserved machines that are no longer needed. It
+	// Unreserve accepts a session that has reserved machines that are no longer needed. It
 	// increases the number of available machines to allow other sessions to provision
 	// resources. It does not actually return, tear down or delete any machine or resources.
 	//
 	// This method makes an assumption that Reserve has been called on the session, performing
 	// no checks that the available machines in each pool do not exceeds their capacities.
 	//
-	// If a component references a pool that was not added to the availability instance, it
+	// If a component references a pool that was Unreserve added to the availability instance, it
 	// returns a PoolUnknownError.
-	Return(session *types.Session) error
+	Unreserve(session *types.Session) error
 }
 
 // ReservationManager contains a set of pools and manages the availability of their machines. It is
@@ -132,16 +132,16 @@ func (rm *ReservationManager) Reserve(session *types.Session) error {
 	return nil
 }
 
-// Return accepts a session that has reserved machines that are no longer needed. It increases the
-// number of available machines to allow other sessions to provision resources. It does not actually
-// return, tear down or delete any machine or resources.
+// Unreserve accepts a session that has reserved machines that are no longer needed. It increases
+// the number of available machines to allow other sessions to provision resources. It does not
+// actually return, tear down or delete any machine or resources.
 //
 // This method makes an assumption that Reserve has been called on the session, performing no checks
 // that the available machines in each pool do not exceeds their capacities.
 //
 // If a component references a pool that was not added to the availability instance, it returns a
 // PoolUnknownError.
-func (rm *ReservationManager) Return(session *types.Session) error {
+func (rm *ReservationManager) Unreserve(session *types.Session) error {
 	components := sessionComponents(session)
 
 	machineCounts, err := rm.machineCounts(components)

--- a/testctrl/svc/orch/reservation.go
+++ b/testctrl/svc/orch/reservation.go
@@ -51,7 +51,7 @@ type ReservationLimiter interface {
 	// If there are not enough machines available in the specified pools to accomodate the
 	// session, it returns a PoolAvailabilityError. If a component references a pool that was
 	// not added to the availability instance, it returns a PoolUnknownError. If the number of
-	// machines required by the session exheeds the capacity of the pools, it returns a
+	// machines required by the session exceeds the capacity of the pools, it returns a
 	// PoolCapacityError.
 	Reserve(session *types.Session) error
 
@@ -60,7 +60,7 @@ type ReservationLimiter interface {
 	// resources. It does not actually return, tear down or delete any machine or resources.
 	//
 	// This method makes an assumption that Reserve has been called on the session, performing
-	// no checks that the available machines in each pool do not exheed their capacities.
+	// no checks that the available machines in each pool do not exceeds their capacities.
 	//
 	// If a component references a pool that was not added to the availability instance, it
 	// returns a PoolUnknownError.
@@ -107,7 +107,7 @@ func (rm *ReservationManager) RemovePool(pool Pool) error {
 // If there are not enough machines available in the specified pools to accomodate the session, it
 // returns a PoolAvailabilityError. If a component references a pool that was not added to the
 // availability instance, it returns a PoolUnknownError. If the number of machines required by the
-// session exheeds the capacity of the pools, it returns a PoolCapacityError.
+// session exceeds the capacity of the pools, it returns a PoolCapacityError.
 func (rm *ReservationManager) Reserve(session *types.Session) error {
 	components := sessionComponents(session)
 
@@ -137,7 +137,7 @@ func (rm *ReservationManager) Reserve(session *types.Session) error {
 // return, tear down or delete any machine or resources.
 //
 // This method makes an assumption that Reserve has been called on the session, performing no checks
-// that the available machines in each pool do not exheed their capacities.
+// that the available machines in each pool do not exceeds their capacities.
 //
 // If a component references a pool that was not added to the availability instance, it returns a
 // PoolUnknownError.
@@ -180,7 +180,7 @@ func (rm *ReservationManager) machineCounts(components []*types.Component) (map[
 
 // fits accepts a map with pool names as keys and number of required machines within the pool as
 // values. It returns true if there are enough available resources to schedule. If the number of
-// machines required exheeds the capacity of the pools, it returns a PoolCapacityError.
+// machines required exceeds the capacity of the pools, it returns a PoolCapacityError.
 func (rm *ReservationManager) fits(machineCounts map[string]int) (bool, error) {
 	for poolName, c := range machineCounts {
 		pool := rm.pools[poolName]

--- a/testctrl/svc/orch/reservation.go
+++ b/testctrl/svc/orch/reservation.go
@@ -125,7 +125,6 @@ func (rm *ReservationManager) Reserve(session *types.Session) error {
 	return nil
 }
 
-
 // Unreserve increases the number of available machines by the number of machines a session
 // required. Essentially, it reverses the actions of the Reserve function.
 //

--- a/testctrl/svc/orch/reservation_test.go
+++ b/testctrl/svc/orch/reservation_test.go
@@ -1,0 +1,245 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orch
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+func TestAvailabilityAddPool(t *testing.T) {
+	rm := NewReservationManager()
+	poolName := "TestPool"
+	pool := Pool{Name: poolName}
+
+	rm.AddPool(pool)
+	found, exists := rm.pools[poolName]
+	if !exists {
+		t.Fatalf("did not add pool to internal map")
+	}
+	if !reflect.DeepEqual(pool, found) {
+		t.Fatalf("unexpectedly mutated pool during addition")
+	}
+}
+
+func TestAvailabilityRemovePool(t *testing.T) {
+	rm := NewReservationManager()
+	pool := Pool{
+		Name:      "TestPool",
+		Available: 10,
+		Capacity:  100,
+	}
+
+	// test remove with original object
+	rm.pools[pool.Name] = pool
+	rm.RemovePool(pool)
+	if _, exists := rm.pools[pool.Name]; exists {
+		t.Errorf("did not remove original pool from internal map")
+	}
+
+	// test remove with identically-named object
+	rm.pools[pool.Name] = pool
+	rm.RemovePool(Pool{Name: pool.Name})
+	if _, exists := rm.pools[pool.Name]; exists {
+		t.Errorf("did not remove pool with identical name from internal map")
+	}
+
+	// test error raised if pool does not exist
+	fakePool := Pool{Name: "WaymoPool"}
+	if err := rm.RemovePool(fakePool); err == nil {
+		t.Errorf("did not error for non-existent pool")
+	}
+}
+
+func TestAvailabilityReserve(t *testing.T) {
+	cases := []struct {
+		description      string
+		workerCount      int
+		workerPoolBefore Pool
+		workerPoolAfter  Pool
+		err              error
+	}{
+		{
+			description:      "capacity exheeded",
+			workerCount:      5,
+			workerPoolBefore: Pool{Available: 4, Capacity: 4},
+			workerPoolAfter:  Pool{Available: 4, Capacity: 4},
+			err:              PoolCapacityError{},
+		},
+		{
+			description:      "not available",
+			workerCount:      7,
+			workerPoolBefore: Pool{Available: 5, Capacity: 7},
+			workerPoolAfter:  Pool{Available: 5, Capacity: 7},
+			err:              PoolAvailabilityError{},
+		},
+		{
+			description:      "exact availability match",
+			workerCount:      3,
+			workerPoolBefore: Pool{Available: 3, Capacity: 3},
+			workerPoolAfter:  Pool{Available: 0, Capacity: 3},
+			err:              nil,
+		},
+		{
+			description:      "availability match greater",
+			workerCount:      3,
+			workerPoolBefore: Pool{Available: 8, Capacity: 9},
+			workerPoolAfter:  Pool{Available: 5, Capacity: 9},
+			err:              nil,
+		},
+	}
+
+	for _, c := range cases {
+		rm := NewReservationManager()
+
+		driverPool := Pool{
+			Name:      "DriverPool",
+			Available: 1,
+			Capacity:  1,
+		}
+		rm.AddPool(driverPool)
+
+		workerPool := c.workerPoolBefore
+		workerPool.Name = "WorkerPool"
+		rm.AddPool(workerPool)
+
+		driver := types.NewComponent(testContainerImage, types.DriverComponent)
+		driver.PoolName = driverPool.Name
+
+		var workers []*types.Component
+		for i := 0; i < c.workerCount; i++ {
+			component := types.NewComponent(testContainerImage, types.ClientComponent)
+			component.PoolName = workerPool.Name
+			workers = append(workers, component)
+		}
+
+		session := types.NewSession(driver, workers, nil)
+
+		err := rm.Reserve(session)
+		expectedErrType := reflect.TypeOf(c.err)
+		actualErrType := reflect.TypeOf(err)
+		if c.err != nil {
+			// check for the proper error
+			if expectedErrType != actualErrType {
+				t.Errorf("expected %v error for case %v, but got %v: %v",
+					expectedErrType.Name(), c.description, actualErrType.Name(), err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error returned: %v", err)
+			}
+		}
+
+		got := rm.pools[workerPool.Name]
+		if got.Available != c.workerPoolAfter.Available {
+			t.Errorf("expected %v machines remaining after reserve, but got %v",
+				c.workerPoolAfter.Available, got.Available)
+		}
+		if got.Capacity != c.workerPoolAfter.Capacity {
+			t.Errorf("expected %v machine capacity after reserve, but got %v",
+				c.workerPoolAfter.Capacity, got.Capacity)
+		}
+	}
+
+	// check error returned for unknown pool
+	rm := NewReservationManager()
+	rm.AddPool(Pool{Name: "KnownPool"})
+
+	driver := types.NewComponent(testContainerImage, types.DriverComponent)
+	driver.PoolName = "UnknownPool"
+
+	session := types.NewSession(driver, nil, nil)
+
+	err := rm.Reserve(session)
+	errType := reflect.TypeOf(err)
+	if errType == nil || errType != reflect.TypeOf(PoolUnknownError{}) {
+		t.Errorf("expected pool unknown error for un-added pool, but got %v", errType.Name())
+	}
+}
+
+func TestAvailabilityReturn(t *testing.T) {
+	cases := []struct {
+		description      string
+		workerCount      int
+		workerPoolBefore Pool
+		workerPoolAfter  Pool
+	}{
+		{
+			description:      "default",
+			workerCount:      3,
+			workerPoolBefore: Pool{Available: 4, Capacity: 7},
+			workerPoolAfter:  Pool{Available: 7, Capacity: 7},
+		},
+	}
+
+	for _, c := range cases {
+		rm := NewReservationManager()
+
+		driverPool := Pool{
+			Name:      "DriverPool",
+			Available: 1,
+			Capacity:  1,
+		}
+		rm.AddPool(driverPool)
+
+		workerPool := c.workerPoolBefore
+		workerPool.Name = "WorkerPool"
+		rm.AddPool(workerPool)
+
+		driver := types.NewComponent(testContainerImage, types.DriverComponent)
+		driver.PoolName = driverPool.Name
+
+		var workers []*types.Component
+		for i := 0; i < c.workerCount; i++ {
+			component := types.NewComponent(testContainerImage, types.ClientComponent)
+			component.PoolName = workerPool.Name
+			workers = append(workers, component)
+		}
+
+		session := types.NewSession(driver, workers, nil)
+
+		err := rm.Return(session)
+		if err != nil {
+			t.Errorf("unexpected error returned: %v", err)
+		}
+
+		got := rm.pools[workerPool.Name]
+		if got.Available != c.workerPoolAfter.Available {
+			t.Errorf("expected %v machines remaining after return, but got %v",
+				c.workerPoolAfter.Available, got.Available)
+		}
+		if got.Capacity != c.workerPoolAfter.Capacity {
+			t.Errorf("expected %v machine capacity after return, but got %v",
+				c.workerPoolAfter.Capacity, got.Capacity)
+		}
+	}
+
+	// check error returned for unknown pool
+	rm := NewReservationManager()
+	rm.AddPool(Pool{Name: "KnownPool"})
+
+	driver := types.NewComponent(testContainerImage, types.DriverComponent)
+	driver.PoolName = "UnknownPool"
+
+	session := types.NewSession(driver, nil, nil)
+
+	err := rm.Return(session)
+	errType := reflect.TypeOf(err)
+	if errType == nil || errType != reflect.TypeOf(PoolUnknownError{}) {
+		t.Errorf("expected pool unknown error for un-added pool, but got %v", errType.Name())
+	}
+}

--- a/testctrl/svc/orch/reservation_test.go
+++ b/testctrl/svc/orch/reservation_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/grpc/grpc/testctrl/svc/types"
 )
 
-func TestAvailabilityAddPool(t *testing.T) {
+func TestReservationManagerAddPool(t *testing.T) {
 	rm := NewReservationManager()
 	poolName := "TestPool"
 	pool := Pool{Name: poolName}
@@ -36,7 +36,7 @@ func TestAvailabilityAddPool(t *testing.T) {
 	}
 }
 
-func TestAvailabilityRemovePool(t *testing.T) {
+func TestReservationManagerRemovePool(t *testing.T) {
 	rm := NewReservationManager()
 	pool := Pool{
 		Name:      "TestPool",
@@ -65,7 +65,7 @@ func TestAvailabilityRemovePool(t *testing.T) {
 	}
 }
 
-func TestAvailabilityReserve(t *testing.T) {
+func TestReservationManagerReserve(t *testing.T) {
 	cases := []struct {
 		description      string
 		workerCount      int
@@ -171,7 +171,7 @@ func TestAvailabilityReserve(t *testing.T) {
 	}
 }
 
-func TestAvailabilityUnreserve(t *testing.T) {
+func TestReservationManagerUnreserve(t *testing.T) {
 	cases := []struct {
 		description      string
 		workerCount      int

--- a/testctrl/svc/orch/reservation_test.go
+++ b/testctrl/svc/orch/reservation_test.go
@@ -171,7 +171,7 @@ func TestAvailabilityReserve(t *testing.T) {
 	}
 }
 
-func TestAvailabilityReturn(t *testing.T) {
+func TestAvailabilityUnreserve(t *testing.T) {
 	cases := []struct {
 		description      string
 		workerCount      int
@@ -212,7 +212,7 @@ func TestAvailabilityReturn(t *testing.T) {
 
 		session := types.NewSession(driver, workers, nil)
 
-		err := rm.Return(session)
+		err := rm.Unreserve(session)
 		if err != nil {
 			t.Errorf("unexpected error returned: %v", err)
 		}
@@ -237,7 +237,7 @@ func TestAvailabilityReturn(t *testing.T) {
 
 	session := types.NewSession(driver, nil, nil)
 
-	err := rm.Return(session)
+	err := rm.Unreserve(session)
 	errType := reflect.TypeOf(err)
 	if errType == nil || errType != reflect.TypeOf(PoolUnknownError{}) {
 		t.Errorf("expected pool unknown error for un-added pool, but got %v", errType.Name())

--- a/testctrl/svc/orch/reservation_test.go
+++ b/testctrl/svc/orch/reservation_test.go
@@ -74,7 +74,7 @@ func TestAvailabilityReserve(t *testing.T) {
 		err              error
 	}{
 		{
-			description:      "capacity exheeded",
+			description:      "capacity exceeded",
 			workerCount:      5,
 			workerPoolBefore: Pool{Available: 4, Capacity: 4},
 			workerPoolAfter:  Pool{Available: 4, Capacity: 4},

--- a/testctrl/svc/orch/testing.go
+++ b/testctrl/svc/orch/testing.go
@@ -1,0 +1,4 @@
+package orch
+
+// testContainerImage is a default container image supplied during component construction in tests.
+const testContainerImage = "example:latest"


### PR DESCRIPTION
This change adds a custom Queue type. It uses a ReservationLimiter to only dequeue sessions that can be scheduled with the machines that are currently available.

Note this commit does not remove the kubernetes queue in the controller. This only implements a new one. The replacement will happen in a later commit.