### PR TITLE
Set WORKER_KIND env variable for servers & clients

### DIFF
--- a/testctrl/svc/orch/spec_builder.go
+++ b/testctrl/svc/orch/spec_builder.go
@@ -126,10 +126,21 @@ func (sb *SpecBuilder) Env() []apiv1.EnvVar {
 		})
 	}
 
-	if sb.component.Kind == types.DriverComponent {
+	switch sb.component.Kind {
+	case types.DriverComponent:
 		vars = append(vars, apiv1.EnvVar{
 			Name:  "SCENARIO_JSON",
 			Value: sb.scenarioJson(),
+		})
+	case types.ServerComponent:
+		vars = append(vars, apiv1.EnvVar{
+			Name:  "WORKER_KIND",
+			Value: "server",
+		})
+	case types.ClientComponent:
+		vars = append(vars, apiv1.EnvVar{
+			Name:  "WORKER_KIND",
+			Value: "client",
 		})
 	}
 


### PR DESCRIPTION
The Docker images of the workers use a $WORKER_KIND env variable to distinguish between a client and server. This change explicitly sets the env variable.