### PR TITLE
Add elementary validator package to combat bad sessions

### DIFF
--- a/testctrl/svc/validator/doc.go
+++ b/testctrl/svc/validator/doc.go
@@ -1,0 +1,3 @@
+// The validator package provides a library for validating sessions and
+// before they are trusted to run on physical machines.
+package validator

--- a/testctrl/svc/validator/doc.go
+++ b/testctrl/svc/validator/doc.go
@@ -1,3 +1,3 @@
-// The validator package provides a library for validating sessions and
-// before they are trusted to run on physical machines.
+// The validator package provides a library for validating sessions before they
+// are trusted to run on physical machines.
 package validator

--- a/testctrl/svc/validator/validator.go
+++ b/testctrl/svc/validator/validator.go
@@ -18,6 +18,11 @@ type Validator struct {
 	// images by Google Cloud Project. It assigns all images a name like
 	// `gcr.io/<project>/<image>`. To enforce that all images came from a
 	// specific GCR project, we can set this value to `gcr.io/<project>/`.
+	//
+	// BE SURE TO INCLUDE THE FINAL SLASH, OTHERWISE THE PREFIX DOES NOT
+	// ENFORCE IT CAME FROM A SPECIFIC GCP PROJECT. For example, specifying
+	// `gcr.io/fake-project` as the prefix will allow an image named
+	// `gcr.io/fake-project-different-owner/malware`.
 	ImageNamePrefix string
 }
 

--- a/testctrl/svc/validator/validator.go
+++ b/testctrl/svc/validator/validator.go
@@ -1,0 +1,55 @@
+package validator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+// Validator verifies that sessions conform to a list of requirements. Each of
+// its fields can be used to enable, disable or adjust the requirements.
+type Validator struct {
+	// ImageNamePrefix enforces that all container image names have its
+	// prefix. If not specified, all container image names will be valid.
+	//
+	// On certain registries, requiring a prefix can make the cluster more
+	// secure. For example, Google Container Registry scopes container
+	// images by Google Cloud Project. It assigns all images a name like
+	// `gcr.io/<project>/<image>`. To enforce that all images came from a
+	// specific GCR project, we can set this value to `gcr.io/<project>/`.
+	ImageNamePrefix string
+}
+
+// Validate checks that the session meets all requirements. If not, it returns
+// an error with the first violation it encounters.
+func (v *Validator) Validate(session *types.Session) error {
+	// TODO: Add more validations
+	return v.validateImages(session)
+}
+
+func (v *Validator) validImageName(name string) bool {
+	return strings.HasPrefix(name, v.ImageNamePrefix)
+}
+
+func (v *Validator) validateImages(session *types.Session) error {
+	driver := session.Driver
+	if driver == nil {
+		return fmt.Errorf("driver component required, but is missing")
+	}
+
+	driverImage := driver.ContainerImage
+	if !v.validImageName(driverImage) {
+		return fmt.Errorf("driver container image %q does not have required prefix %q",
+			driverImage, v.ImageNamePrefix)
+	}
+
+	for _, worker := range session.Workers {
+		workerImage := worker.ContainerImage
+		if !v.validImageName(workerImage) {
+			return fmt.Errorf("%v container image %q does not have required prefix %q",
+				strings.ToLower(worker.Kind.String()), workerImage, v.ImageNamePrefix)
+		}
+	}
+	return nil
+}

--- a/testctrl/svc/validator/validator.go
+++ b/testctrl/svc/validator/validator.go
@@ -40,14 +40,14 @@ func (v *Validator) validateImages(session *types.Session) error {
 
 	driverImage := driver.ContainerImage
 	if !v.validImageName(driverImage) {
-		return fmt.Errorf("driver container image %q does not have required prefix %q",
+		return fmt.Errorf("driver container image %q missing required prefix %q",
 			driverImage, v.ImageNamePrefix)
 	}
 
 	for _, worker := range session.Workers {
 		workerImage := worker.ContainerImage
 		if !v.validImageName(workerImage) {
-			return fmt.Errorf("%v container image %q does not have required prefix %q",
+			return fmt.Errorf("%v container image %q missing required prefix %q",
 				strings.ToLower(worker.Kind.String()), workerImage, v.ImageNamePrefix)
 		}
 	}

--- a/testctrl/svc/validator/validator_test.go
+++ b/testctrl/svc/validator/validator_test.go
@@ -1,0 +1,142 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/grpc/grpc/testctrl/svc/types"
+)
+
+func TestValidatorValidate(t *testing.T) {
+	t.Run("driver", func(t *testing.T) {
+		cases := []struct {
+			driverNil   bool
+			shouldError bool
+		}{
+			{driverNil: true, shouldError: true},
+			{driverNil: false, shouldError: false},
+		}
+
+		for _, tc := range cases {
+			description := "missing"
+			if !tc.driverNil {
+				description = "present"
+			}
+
+			t.Run(description, func(t *testing.T) {
+				validator := &Validator{}
+
+				var driver *types.Component
+				if !tc.driverNil {
+					driver = types.NewComponent("driver-image", types.DriverComponent)
+				}
+
+				workers := []*types.Component{
+					types.NewComponent("server-image", types.ServerComponent),
+					types.NewComponent("client-image", types.ClientComponent),
+				}
+
+				// TODO: Replace <nil> scenario when scenario validations are added
+				session := types.NewSession(driver, workers, nil)
+
+				err := validator.Validate(session)
+
+				if tc.shouldError && err == nil {
+					t.Fatalf("did not error")
+				} else if !tc.shouldError && err != nil {
+					t.Fatalf("returned unexpected error: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("image name prefix", func(t *testing.T) {
+		cases := []struct {
+			description  string
+			prefix       string
+			driverImage  string
+			serverImage  string
+			clientImages []string
+			shouldError  bool
+		}{
+			{
+				description: "match",
+				prefix:      "gcr.io/grpc-fake",
+				driverImage: "gcr.io/grpc-fake/valid-image",
+				serverImage: "gcr.io/grpc-fake/valid-image",
+				clientImages: []string{
+					"gcr.io/grpc-fake/valid-image",
+					"gcr.io/grpc-fake/valid-image",
+				},
+				shouldError: false,
+			},
+			{
+				description: "mismatch in driver",
+				prefix:      "gcr.io/grpc-fake",
+				driverImage: "gcr.io/grpc-fak/invalid-image",
+				serverImage: "gcr.io/grpc-fake/valid-image",
+				clientImages: []string{
+					"gcr.io/grpc-fake/valid-image",
+					"gcr.io/grpc-fake/valid-image",
+				},
+				shouldError: true,
+			},
+			{
+				description: "mismatch in server",
+				prefix:      "gcr.io/grpc-fake",
+				driverImage: "gcr.io/grpc-fake/valid-image",
+				serverImage: "gcr.io/grpc-fak/invalid-image",
+				clientImages: []string{
+					"gcr.io/grpc-fake/valid-image",
+					"gcr.io/grpc-fake/valid-image",
+				},
+				shouldError: true,
+			},
+			{
+				description: "mismatch in client 1",
+				prefix:      "gcr.io/grpc-fake",
+				driverImage: "gcr.io/grpc-fake/valid-image",
+				serverImage: "gcr.io/grpc-fake/valid-image",
+				clientImages: []string{
+					"gcr.io/grpc-fak/invalid-image",
+					"gcr.io/grpc-fake/valid-image",
+				},
+				shouldError: true,
+			},
+			{
+				description: "mismatch in client 2",
+				prefix:      "gcr.io/grpc-fake",
+				driverImage: "gcr.io/grpc-fake/valid-image",
+				serverImage: "gcr.io/grpc-fake/valid-image",
+				clientImages: []string{
+					"gcr.io/grpc-fake/valid-image",
+					"gcr.io/grpc-fak/invalid-image",
+				},
+				shouldError: true,
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.description, func(t *testing.T) {
+				validator := &Validator{ImageNamePrefix: tc.prefix}
+
+				var workers []*types.Component
+				workers = append(workers, types.NewComponent(tc.serverImage, types.ServerComponent))
+				for _, clientImage := range tc.clientImages {
+					workers = append(workers, types.NewComponent(clientImage, types.ClientComponent))
+				}
+				driver := types.NewComponent(tc.driverImage, types.DriverComponent)
+
+				// TODO: Replace <nil> scenario when scenario validations are added
+				session := types.NewSession(driver, workers, nil)
+
+				err := validator.Validate(session)
+
+				if tc.shouldError && err == nil {
+					t.Fatalf("did not error")
+				} else if !tc.shouldError && err != nil {
+					t.Fatalf("returned unexpected error: %v", err)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
When deploying the service to the cluster, there is a chance that users could request malignant container images as test components. #48 was created to track the creation of a validator to reduce this risk. This change implements an elementary version of it. It ensures that all container images have a specific prefix.

This prefix requirement is beneficial for certain docker registries, like Google Container Registry (GCR). Docker images in GCR are named in the following manner: `[<geo>.]gcr.io/<project>/<image>`, where `project` is the identifier of a Google Cloud Project. Enforcing a prefix ensures that the image came from a certain Google Cloud Project if access to gcr.io is trustworthy.

This approach does not require that the validator package understand the naming conventions. Instead, it relies on a prefix. This allows it to work with other registries.

Unfortunately, there is one caveat with this elementary design.  A geographic area `geo` can be is used to specify a specific area. For example `us.gcr.io` specifies the United States. I believe the default, `gcr.io`, signals global. gRPC does not appear to use this for benchmarks and other tests. So this should not be a problem in the current state. A future version can support it, if necessary.