### PR TITLE
Save orchestration events in the store

### DIFF
--- a/testctrl/cmd/orchtest/main.go
+++ b/testctrl/cmd/orchtest/main.go
@@ -49,7 +49,7 @@ func main() {
 		glog.Fatalf("Invalid config file specified by the KUBE_CONFIG_FILE env variable, unable to connect: %v", err)
 	}
 
-	c, _ := orch.NewController(clientset)
+	c, _ := orch.NewController(clientset, nil)
 	if err := c.Start(); err != nil {
 		panic(err)
 	}

--- a/testctrl/svc/orch/controller_test.go
+++ b/testctrl/svc/orch/controller_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("nil clientset returns error", func(t *testing.T) {
-		controller, err := NewController(nil)
+		controller, err := NewController(nil, nil)
 		if err == nil {
 			t.Errorf("no error returned for nil clientset")
 		}
@@ -50,7 +50,7 @@ func TestControllerSchedule(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			controller, _ := NewController(fake.NewSimpleClientset())
+			controller, _ := NewController(fake.NewSimpleClientset(), nil)
 			executor := &executorMock{}
 			controller.newExecutorFunc = func() Executor {
 				return executor
@@ -84,7 +84,7 @@ func TestControllerSchedule(t *testing.T) {
 
 func TestControllerStart(t *testing.T) {
 	t.Run("sets running state", func(t *testing.T) {
-		controller, _ := NewController(fake.NewSimpleClientset())
+		controller, _ := NewController(fake.NewSimpleClientset(), nil)
 		controller.Start()
 		defer controller.Stop(0)
 		if controller.Stopped() {
@@ -112,7 +112,7 @@ func TestControllerStart(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			controller, _ := NewController(fake.NewSimpleClientset())
+			controller, _ := NewController(fake.NewSimpleClientset(), nil)
 			controller.waitQueue = newQueue(limitlessTracker{})
 
 			if tc.mockNL != nil {
@@ -170,7 +170,7 @@ func TestControllerStop(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			controller, _ := NewController(fake.NewSimpleClientset())
+			controller, _ := NewController(fake.NewSimpleClientset(), nil)
 			controller.running = true
 			controller.waitQueue = newQueue(limitlessTracker{})
 

--- a/testctrl/svc/orch/executor_test.go
+++ b/testctrl/svc/orch/executor_test.go
@@ -23,7 +23,7 @@ func TestKubeExecutorProvision(t *testing.T) {
 	components := []*types.Component{server, client, driver}
 	session := types.NewSession(driver, components[:2], nil)
 
-	e := newKubeExecutor(0, fakePodInf, nil)
+	e := newKubeExecutor(0, fakePodInf, nil, nil)
 	eventChan := make(chan *PodWatchEvent)
 	e.eventChan = eventChan
 	e.session = session
@@ -75,7 +75,7 @@ func TestKubeExecutorProvision(t *testing.T) {
 	components = []*types.Component{server, client, driver}
 	session = types.NewSession(driver, components[:2], nil)
 
-	e = newKubeExecutor(0, fakePodInf, nil)
+	e = newKubeExecutor(0, fakePodInf, nil, nil)
 	eventChan = make(chan *PodWatchEvent)
 	e.eventChan = eventChan
 	e.session = session
@@ -136,7 +136,7 @@ func TestKubeExecutorMonitor(t *testing.T) {
 			components := []*types.Component{server, client, driver}
 			session := types.NewSession(driver, components[:2], nil)
 
-			e := newKubeExecutor(0, fakePodInf, nil)
+			e := newKubeExecutor(0, fakePodInf, nil, nil)
 			eventChan := make(chan *PodWatchEvent)
 			e.eventChan = eventChan
 			e.session = session
@@ -185,7 +185,7 @@ func TestKubeExecutorMonitor(t *testing.T) {
 //	}
 //	podCountBefore := len(pods)
 //
-//	e := newKubeExecutor(0, fakePodInf, nil)
+//	e := newKubeExecutor(0, fakePodInf, nil, nil)
 //	e.session = session
 //	if err = e.clean(fakePodInf); err != nil {
 //		t.Fatalf("returned an error unexpectedly: %v", err)


### PR DESCRIPTION
This change sends session-level orchestration events to the store. It lacks the appropriate testing that the events have been sent and lowers the coverage of orch, because the event system is likely to be
redesigned after the prototype.