### PR TITLE
Marshal internal event description into protobuf

### DIFF
--- a/testctrl/svc/operations_server.go
+++ b/testctrl/svc/operations_server.go
@@ -107,9 +107,10 @@ func newEventProto(e *types.Event) (eventpb *svcpb.Event, err error) {
 		return
 	}
 	eventpb = &svcpb.Event{
-		Subject: e.SubjectName,
-		Kind:    e.Kind.Proto(),
-		Time:    time,
+		Subject:     e.SubjectName,
+		Kind:        e.Kind.Proto(),
+		Description: e.Description,
+		Time:        time,
 	}
 	return
 }


### PR DESCRIPTION
The internal Event instance's description field was not being marshaled into an Event protobuf. This change marshals it.