### PR TITLE
Add options structs and timeouts to orch package

### DIFF
--- a/testctrl/cmd/orchtest/main.go
+++ b/testctrl/cmd/orchtest/main.go
@@ -49,7 +49,7 @@ func main() {
 		glog.Fatalf("Invalid config file specified by the KUBE_CONFIG_FILE env variable, unable to connect: %v", err)
 	}
 
-	c, _ := orch.NewController(clientset, nil)
+	c, _ := orch.NewController(clientset, nil, nil)
 	if err := c.Start(); err != nil {
 		panic(err)
 	}

--- a/testctrl/cmd/orchtest/main.go
+++ b/testctrl/cmd/orchtest/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"os"
@@ -53,7 +54,10 @@ func main() {
 	if err := c.Start(); err != nil {
 		panic(err)
 	}
-	defer c.Stop(*timeout)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+	defer c.Stop(shutdownCtx)
 
 	go func() {
 		for i := 0; i < *count; i++ {

--- a/testctrl/cmd/svc/main.go
+++ b/testctrl/cmd/svc/main.go
@@ -82,7 +82,8 @@ func main() {
 
 	storageServer := store.NewStorageServer()
 
-	controller, err := orch.NewController(clientset, storageServer)
+	controllerOpts := &orch.ControllerOptions{}
+	controller, err := orch.NewController(clientset, storageServer, controllerOpts)
 	if err != nil {
 		glog.Fatalf("could not create a controller: %v", err)
 	}

--- a/testctrl/cmd/svc/main.go
+++ b/testctrl/cmd/svc/main.go
@@ -65,6 +65,7 @@ func setupDevEnv(grpcServer *grpc.Server) *kubernetes.Clientset {
 
 func main() {
 	port := flag.Int("port", 50051, "Port to start the service.")
+	testTimeout := flag.Duration("testTimeout", 15*time.Minute, "Maximum time tests are allowed to run")
 	shutdownTimeout := flag.Duration("shutdownTimeout", 5*time.Minute, "Time alloted to a graceful shutdown.")
 	flag.Parse()
 	defer glog.Flush()
@@ -83,7 +84,9 @@ func main() {
 
 	storageServer := store.NewStorageServer()
 
-	controllerOpts := &orch.ControllerOptions{}
+	controllerOpts := &orch.ControllerOptions{
+		TestTimeout: *testTimeout,
+	}
 	controller, err := orch.NewController(clientset, storageServer, controllerOpts)
 	if err != nil {
 		glog.Fatalf("could not create a controller: %v", err)

--- a/testctrl/cmd/svc/main.go
+++ b/testctrl/cmd/svc/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net"
@@ -92,7 +93,9 @@ func main() {
 		glog.Fatalf("unable to start orchestration controller: %v", err)
 	}
 
-	defer controller.Stop(*shutdownTimeout)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), *shutdownTimeout)
+	defer cancel()
+	defer controller.Stop(shutdownCtx)
 
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {

--- a/testctrl/svc/orch/controller.go
+++ b/testctrl/svc/orch/controller.go
@@ -79,8 +79,8 @@ type ControllerOptions struct {
 // to a user.
 //
 // The options value allows the controller to be customized. Specifying nil will
-// configure the controller to sane defaults described in the ControllerOptions
-// documentation.
+// configure the controller to sane defaults. These defaults are described in
+// the ControllerOptions documentation.
 func NewController(clientset kubernetes.Interface, store store.Store, options *ControllerOptions) (*Controller, error) {
 	if clientset == nil {
 		return nil, errors.New("cannot create controller from nil kubernetes clientset")

--- a/testctrl/svc/orch/controller_test.go
+++ b/testctrl/svc/orch/controller_test.go
@@ -1,6 +1,7 @@
 package orch
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -58,7 +59,7 @@ func TestControllerSchedule(t *testing.T) {
 
 			if tc.start {
 				controller.Start()
-				defer controller.Stop(0)
+				defer controller.Stop(context.TODO())
 			}
 
 			err := controller.Schedule(tc.session)
@@ -86,7 +87,7 @@ func TestControllerStart(t *testing.T) {
 	t.Run("sets running state", func(t *testing.T) {
 		controller, _ := NewController(fake.NewSimpleClientset(), nil, nil)
 		controller.Start()
-		defer controller.Stop(0)
+		defer controller.Stop(context.TODO())
 		if controller.Stopped() {
 			t.Errorf("Stopped unexpectedly returned true after starting controller")
 		}
@@ -196,7 +197,11 @@ func TestControllerStop(t *testing.T) {
 
 			go controller.loop()
 			time.Sleep(timeout)
-			err := controller.Stop(tc.stopTimeout)
+
+			ctx, cancel := context.WithTimeout(context.TODO(), tc.stopTimeout)
+			defer cancel()
+
+			err := controller.Stop(ctx)
 			if tc.shouldError && err == nil {
 				t.Errorf("executors unexpectedly finished before timeout")
 			} else if !tc.shouldError && err != nil {

--- a/testctrl/svc/orch/controller_test.go
+++ b/testctrl/svc/orch/controller_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewController(t *testing.T) {
 	t.Run("nil clientset returns error", func(t *testing.T) {
-		controller, err := NewController(nil, nil)
+		controller, err := NewController(nil, nil, nil)
 		if err == nil {
 			t.Errorf("no error returned for nil clientset")
 		}
@@ -50,7 +50,7 @@ func TestControllerSchedule(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			controller, _ := NewController(fake.NewSimpleClientset(), nil)
+			controller, _ := NewController(fake.NewSimpleClientset(), nil, nil)
 			executor := &executorMock{}
 			controller.newExecutorFunc = func() Executor {
 				return executor
@@ -84,7 +84,7 @@ func TestControllerSchedule(t *testing.T) {
 
 func TestControllerStart(t *testing.T) {
 	t.Run("sets running state", func(t *testing.T) {
-		controller, _ := NewController(fake.NewSimpleClientset(), nil)
+		controller, _ := NewController(fake.NewSimpleClientset(), nil, nil)
 		controller.Start()
 		defer controller.Stop(0)
 		if controller.Stopped() {
@@ -112,7 +112,7 @@ func TestControllerStart(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			controller, _ := NewController(fake.NewSimpleClientset(), nil)
+			controller, _ := NewController(fake.NewSimpleClientset(), nil, nil)
 			controller.waitQueue = newQueue(limitlessTracker{})
 
 			if tc.mockNL != nil {
@@ -121,7 +121,7 @@ func TestControllerStart(t *testing.T) {
 
 			if tc.mockPW != nil {
 				controller.pw = tc.mockPW
-				controller.watcher = NewWatcher(tc.mockPW)
+				controller.watcher = NewWatcher(tc.mockPW, nil)
 			}
 
 			err := controller.Start()
@@ -170,7 +170,7 @@ func TestControllerStop(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			controller, _ := NewController(fake.NewSimpleClientset(), nil)
+			controller, _ := NewController(fake.NewSimpleClientset(), nil, nil)
 			controller.running = true
 			controller.waitQueue = newQueue(limitlessTracker{})
 

--- a/testctrl/svc/orch/controller_test.go
+++ b/testctrl/svc/orch/controller_test.go
@@ -59,7 +59,7 @@ func TestControllerSchedule(t *testing.T) {
 
 			if tc.start {
 				controller.Start()
-				defer controller.Stop(context.TODO())
+				defer controller.Stop(context.Background())
 			}
 
 			err := controller.Schedule(tc.session)
@@ -87,7 +87,7 @@ func TestControllerStart(t *testing.T) {
 	t.Run("sets running state", func(t *testing.T) {
 		controller, _ := NewController(fake.NewSimpleClientset(), nil, nil)
 		controller.Start()
-		defer controller.Stop(context.TODO())
+		defer controller.Stop(context.Background())
 		if controller.Stopped() {
 			t.Errorf("Stopped unexpectedly returned true after starting controller")
 		}
@@ -198,7 +198,7 @@ func TestControllerStop(t *testing.T) {
 			go controller.loop()
 			time.Sleep(timeout)
 
-			ctx, cancel := context.WithTimeout(context.TODO(), tc.stopTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), tc.stopTimeout)
 			defer cancel()
 
 			err := controller.Stop(ctx)

--- a/testctrl/svc/orch/executor_test.go
+++ b/testctrl/svc/orch/executor_test.go
@@ -71,7 +71,19 @@ func TestKubeExecutorProvision(t *testing.T) {
 				{
 					component: types.ServerComponent,
 					sleep:     10 * time.Second * timeMultiplier,
-					health:    Failed,
+					health:    Succeeded,
+					podIP:     "127.0.0.1",
+				},
+				{
+					component: types.ClientComponent,
+					sleep:     10 * time.Second * timeMultiplier,
+					health:    Succeeded,
+					podIP:     "127.0.0.1",
+				},
+				{
+					component: types.DriverComponent,
+					sleep:     10 * time.Second * timeMultiplier,
+					health:    Succeeded,
 					podIP:     "127.0.0.1",
 				},
 			},

--- a/testctrl/svc/orch/executor_test.go
+++ b/testctrl/svc/orch/executor_test.go
@@ -1,9 +1,11 @@
 package orch
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,105 +15,166 @@ import (
 )
 
 func TestKubeExecutorProvision(t *testing.T) {
-	// test provision with successful pods
-	fakePodInf := newFakePodInterface(t)
 
-	driver := types.NewComponent(testContainerImage, types.DriverComponent)
-	server := types.NewComponent(testContainerImage, types.ServerComponent)
-	client := types.NewComponent(testContainerImage, types.ClientComponent)
-
-	components := []*types.Component{server, client, driver}
-	session := types.NewSession(driver, components[:2], nil)
-
-	e := newKubeExecutor(0, fakePodInf, nil, nil)
-	eventChan := make(chan *PodWatchEvent)
-	e.eventChan = eventChan
-	e.session = session
-
-	go func() {
-		for _, c := range components {
-			eventChan <- &PodWatchEvent{
-				SessionName:   session.Name,
-				ComponentName: c.Name,
-				Pod:           nil,
-				PodIP:         "127.0.0.1",
-				Health:        Ready,
-				Error:         nil,
-			}
-		}
-	}()
-
-	if err := e.provision(); err != nil {
-		t.Fatalf("unexpected error in provision: %v", err)
+	cases := []struct {
+		description string
+		events      []fakeWatchEvent
+		ctxTimeout  time.Duration
+		errors      bool
+	}{
+		{
+			description: "successful pods",
+			events: []fakeWatchEvent{
+				{
+					component: types.ServerComponent,
+					health:    Ready,
+					podIP:     "127.0.0.1",
+				},
+				{
+					component: types.ClientComponent,
+					health:    Ready,
+					podIP:     "127.0.0.1",
+				},
+				{
+					component: types.DriverComponent,
+					health:    Ready,
+					podIP:     "127.0.0.1",
+				},
+			},
+			errors: false,
+		},
+		{
+			description: "failed driver pod",
+			events: []fakeWatchEvent{
+				{
+					component: types.ServerComponent,
+					health:    Ready,
+					podIP:     "127.0.0.1",
+				},
+				{
+					component: types.ClientComponent,
+					health:    Ready,
+					podIP:     "127.0.0.1",
+				},
+				{
+					component: types.DriverComponent,
+					health:    Failed,
+					podIP:     "127.0.0.1",
+				},
+			},
+			errors: true,
+		},
+		{
+			description: "cancelled context",
+			ctxTimeout:  1 * time.Millisecond * timeMultiplier,
+			events: []fakeWatchEvent{
+				{
+					component: types.ServerComponent,
+					sleep:     10 * time.Second * timeMultiplier,
+					health:    Failed,
+					podIP:     "127.0.0.1",
+				},
+			},
+			errors: true,
+		},
 	}
 
-	pods, err := listPods(t, fakePodInf)
-	if err != nil {
-		t.Fatalf("could not list pods from provision: %v", err)
-	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			fakePodInf := newFakePodInterface(t)
 
-	expectedNames := []string{driver.Name, server.Name, client.Name}
-	for _, en := range expectedNames {
-		found := false
+			server := types.NewComponent(testContainerImage, types.ServerComponent)
+			client := types.NewComponent(testContainerImage, types.ClientComponent)
+			driver := types.NewComponent(testContainerImage, types.DriverComponent)
 
-		for _, pod := range pods {
-			if strings.Compare(pod.ObjectMeta.Name, en) == 0 {
-				found = true
+			components := []*types.Component{server, client, driver}
+			session := types.NewSession(driver, components[:2], nil)
+
+			e := &kubeExecutor{
+				name:    "provision-test-executor",
+				pcd:     fakePodInf,
+				watcher: nil,
+				store:   nil,
 			}
-		}
+			eventChan := make(chan *PodWatchEvent)
+			e.eventChan = eventChan
+			e.session = session
 
-		if !found {
-			t.Errorf("provision did not create pod for component %v", en)
-		}
-	}
+			go func() {
+				for _, event := range tc.events {
+					var component *types.Component
 
-	// test provision with an unsuccessful pod
-	fakePodInf = newFakePodInterface(t)
+					switch event.component {
+					case types.ServerComponent:
+						component = server
+					case types.ClientComponent:
+						component = client
+					case types.DriverComponent:
+						component = driver
+					default:
+						t.Fatalf("bad component kind")
+					}
 
-	driver = types.NewComponent(testContainerImage, types.DriverComponent)
-	server = types.NewComponent(testContainerImage, types.ServerComponent)
-	client = types.NewComponent(testContainerImage, types.ClientComponent)
+					time.Sleep(event.sleep)
+					eventChan <- &PodWatchEvent{
+						SessionName:   session.Name,
+						ComponentName: component.Name,
+						Pod:           nil,
+						PodIP:         event.podIP,
+						Health:        event.health,
+						Error:         nil,
+					}
+				}
+			}()
 
-	components = []*types.Component{server, client, driver}
-	session = types.NewSession(driver, components[:2], nil)
-
-	e = newKubeExecutor(0, fakePodInf, nil, nil)
-	eventChan = make(chan *PodWatchEvent)
-	e.eventChan = eventChan
-	e.session = session
-
-	go func() {
-		for _, c := range components[:2] {
-			eventChan <- &PodWatchEvent{
-				SessionName:   session.Name,
-				ComponentName: c.Name,
-				Pod:           nil,
-				PodIP:         "127.0.0.1",
-				Health:        Ready,
-				Error:         nil,
+			ctx, cancel := context.WithCancel(context.Background())
+			if tc.ctxTimeout > 0 {
+				ctx, _ = context.WithTimeout(ctx, tc.ctxTimeout)
 			}
-		}
+			defer cancel()
 
-		eventChan <- &PodWatchEvent{
-			SessionName:   session.Name,
-			ComponentName: components[2].Name,
-			Pod:           nil,
-			PodIP:         "",
-			Health:        Failed,
-			Error:         nil,
-		}
-	}()
+			err := e.provision(ctx)
+			if tc.errors {
+				if err == nil {
+					t.Fatalf("provision did not error")
+				}
+				return
+			}
 
-	if err := e.provision(); err == nil {
-		t.Errorf("expected error for failing pod, but returned nil")
+			if err != nil {
+				t.Fatalf("unexpected error in provision: %v", err)
+			}
+
+			pods, err := listPods(t, fakePodInf)
+			if err != nil {
+				t.Fatalf("could not list pods from provision: %v", err)
+			}
+
+			expectedNames := []string{driver.Name, server.Name, client.Name}
+			for _, en := range expectedNames {
+				found := false
+
+				for _, pod := range pods {
+					if strings.Compare(pod.ObjectMeta.Name, en) == 0 {
+						found = true
+					}
+				}
+
+				if !found {
+					t.Errorf("provision did not create pod for component %v", en)
+				}
+			}
+		})
 	}
 }
 
 func TestKubeExecutorMonitor(t *testing.T) {
 	cases := []struct {
-		description string
-		event       *PodWatchEvent
-		errors      bool
+		description  string
+		event        *PodWatchEvent
+		eventTimeout time.Duration
+		ctxTimeout   time.Duration
+		errors       bool
 	}{
 		{
 			description: "success event received",
@@ -122,6 +185,13 @@ func TestKubeExecutorMonitor(t *testing.T) {
 			description: "failure event received",
 			event:       &PodWatchEvent{Health: Failed},
 			errors:      true,
+		},
+		{
+			description:  "cancelled context",
+			event:        &PodWatchEvent{Health: Succeeded},
+			eventTimeout: 10 * time.Second * timeMultiplier,
+			ctxTimeout:   1 * time.Millisecond * timeMultiplier,
+			errors:       true,
 		},
 	}
 
@@ -136,12 +206,18 @@ func TestKubeExecutorMonitor(t *testing.T) {
 			components := []*types.Component{server, client, driver}
 			session := types.NewSession(driver, components[:2], nil)
 
-			e := newKubeExecutor(0, fakePodInf, nil, nil)
+			e := &kubeExecutor{
+				name:    "",
+				pcd:     fakePodInf,
+				watcher: nil,
+				store:   nil,
+			}
 			eventChan := make(chan *PodWatchEvent)
 			e.eventChan = eventChan
 			e.session = session
 
 			go func() {
+				time.Sleep(tc.eventTimeout)
 				eventChan <- &PodWatchEvent{
 					SessionName:   session.Name,
 					ComponentName: driver.Name,
@@ -152,7 +228,13 @@ func TestKubeExecutorMonitor(t *testing.T) {
 				}
 			}()
 
-			err := e.monitor()
+			ctx, cancel := context.WithCancel(context.Background())
+			if tc.ctxTimeout > 0 {
+				ctx, _ = context.WithTimeout(ctx, tc.ctxTimeout)
+			}
+			defer cancel()
+
+			err := e.monitor(ctx)
 			if err == nil && tc.errors {
 				t.Errorf("case '%v' did not return error", tc.description)
 			} else if err != nil && !tc.errors {
@@ -160,6 +242,13 @@ func TestKubeExecutorMonitor(t *testing.T) {
 			}
 		})
 	}
+}
+
+type fakeWatchEvent struct {
+	component types.ComponentKind
+	health    Health
+	sleep     time.Duration
+	podIP     string
 }
 
 // TODO(@codeblooded): Refactor clean method, or choose to not test this method

--- a/testctrl/svc/orch/internal_test.go
+++ b/testctrl/svc/orch/internal_test.go
@@ -1,6 +1,7 @@
 package orch
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -112,7 +113,7 @@ func (pwm *podWatcherMock) Watch(listOpts metav1.ListOptions) (watch.Interface, 
 
 type nodeListerMock struct {
 	nodes []corev1.Node
-	err error
+	err   error
 }
 
 func (nlm *nodeListerMock) List(_ metav1.ListOptions) (*corev1.NodeList, error) {
@@ -144,7 +145,7 @@ type executorMock struct {
 	sessionArg *types.Session
 }
 
-func (em *executorMock) Execute(session *types.Session) error {
+func (em *executorMock) Execute(_ context.Context, session *types.Session) error {
 	em.mux.Lock()
 	defer em.mux.Unlock()
 

--- a/testctrl/svc/orch/watcher.go
+++ b/testctrl/svc/orch/watcher.go
@@ -29,7 +29,7 @@ type Watcher struct {
 	wi              watch.Interface
 }
 
-// WatcherOptions overrides the defaults of the controller, allowing it to be
+// WatcherOptions overrides the defaults of the watcher, allowing it to be
 // configured as needed.
 type WatcherOptions struct {
 	// EventBufferSize specifies the size of the buffered channel for each

--- a/testctrl/svc/orch/watcher_test.go
+++ b/testctrl/svc/orch/watcher_test.go
@@ -28,7 +28,7 @@ func TestWatcherStart(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			w := NewWatcher(tc.mock)
+			w := NewWatcher(tc.mock, nil)
 
 			defer w.Stop()
 			err := w.Start()
@@ -49,7 +49,7 @@ func TestWatcherStop(t *testing.T) {
 
 	wi := watch.NewRaceFreeFake()
 	mock := &podWatcherMock{wi: wi}
-	w := NewWatcher(mock)
+	w := NewWatcher(mock, nil)
 
 	if err = w.Start(); err != nil {
 		t.Fatalf("setup failed, Start returned error: %v", err)
@@ -76,7 +76,7 @@ func TestWatcherSubscribe(t *testing.T) {
 	var event *PodWatchEvent
 	timeout := 100 * time.Millisecond * timeMultiplier
 
-	w := NewWatcher(nil)
+	w := NewWatcher(nil, nil)
 	sharedSessionName := "double-subscription"
 	_, _ = w.Subscribe(sharedSessionName)
 	if _, err = w.Subscribe(sharedSessionName); err == nil {
@@ -85,7 +85,7 @@ func TestWatcherSubscribe(t *testing.T) {
 
 	wi := watch.NewRaceFreeFake()
 	mock := &podWatcherMock{wi: wi}
-	w = NewWatcher(mock)
+	w = NewWatcher(mock, nil)
 
 	if err = w.Start(); err != nil {
 		t.Fatalf("setup failed, Start returned error: %v", err)
@@ -140,7 +140,7 @@ func TestWatcherUnsubscribe(t *testing.T) {
 
 	// test an error is returned without subscription
 	t.Run("no subscription", func(t *testing.T) {
-		w := NewWatcher(nil)
+		w := NewWatcher(nil, nil)
 		if err := w.Unsubscribe("non-existent"); err == nil {
 			t.Errorf("did not return an error for Unsubscribe call without subscription")
 		}
@@ -150,7 +150,7 @@ func TestWatcherUnsubscribe(t *testing.T) {
 	t.Run("prevents further events", func(t *testing.T) {
 		wi := watch.NewRaceFreeFake()
 		mock := &podWatcherMock{wi: wi}
-		w := NewWatcher(mock)
+		w := NewWatcher(mock, nil)
 
 		if err = w.Start(); err != nil {
 			t.Fatalf("setup failed, Start returned error: %v", err)


### PR DESCRIPTION
This change adds an options struct for the Controller and Watcher types, allowing them to be configured. Previously, they used magic constants.